### PR TITLE
feat: Add GET paths for parents and children + fix: Update Neo4J query

### DIFF
--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -14,7 +14,7 @@ from .models import Header, Footer
 
 # DB helper imports
 from .entries import initialize_db, shutdown_db
-from .entries import get_all_nodes, get_nodes
+from .entries import get_all_nodes, get_nodes, get_children, get_parents
 from .entries import update_nodes
 #------------------------------------------------------------------------#
 
@@ -96,6 +96,26 @@ async def findOneEntry(response: Response, entry: str):
     check_single(oneEntry)
     
     return oneEntry[0]
+
+@app.get("/entry/{entry}/parents")
+async def findOneEntryParents(response: Response, entry: str):
+    """
+    Get parents for a entry corresponding to id within taxonomy
+    """
+    result = get_parents(entry)
+    oneEntryParents = list(result)
+    
+    return oneEntryParents
+
+@app.get("/entry/{entry}/children")
+async def findOneEntryChildren(response: Response, entry: str):
+    """
+    Get children for a entry corresponding to id within taxonomy
+    """
+    result = get_children(entry)
+    oneEntryChildren = list(result)
+    
+    return oneEntryChildren
 
 @app.get("/entry")
 async def findAllEntries(response: Response):

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -75,7 +75,7 @@ def update_nodes(label, entry, incomingData):
             raise ValueError("Invalid key: %s", key)
     
     # Build query
-    query = [f"""MATCH (n:{label}) WHERE n.id = $id"""]
+    query = [f"""MATCH (n:{label}) WHERE n.id = $id """, """SET n={} """, """SET n.id = $id"""]
 
     for key in incomingData.keys():
         query.append(f"""\nSET n.{key} = ${key}\n""")

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -3,7 +3,7 @@ Database helper functions for API
 """
 import re
 from neo4j import GraphDatabase         # Interface with Neo4J
-from . import settings                         # Neo4J settings
+from . import settings                  # Neo4J settings
 
 def initialize_db():
     """
@@ -39,6 +39,28 @@ def get_nodes(label, entry):
     query = f"""
         MATCH (n:{label}) WHERE n.id = $id 
         RETURN n
+    """
+    result = session.run(query, {"id": entry})
+    return result
+
+def get_parents(entry):
+    """
+    Helper function used for getting node parents with given id
+    """
+    query = f"""
+        MATCH (a:ENTRY)-[r:is_child_of]->(b) WHERE a.id = $id 
+        RETURN b.id
+    """
+    result = session.run(query, {"id": entry})
+    return result
+
+def get_children(entry):
+    """
+    Helper function used for getting node children with given id
+    """
+    query = f"""
+        MATCH (b)-[r:is_child_of]->(a:ENTRY) WHERE a.id = $id 
+        RETURN b.id
     """
     result = session.run(query, {"id": entry})
     return result

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -76,7 +76,12 @@ def update_nodes(label, entry, incomingData):
     
     # Get current node information and deleted keys
     curr_node = list(get_nodes(label, entry).data()[0]['n'].keys())
-    deleted_keys = list(set(curr_node) ^ set(incomingData))
+    deleted_keys = (set(curr_node) ^ set(incomingData))
+
+    # Check for keys having null/empty values
+    for key in curr_node:
+        if (curr_node[key] == []) or (curr_node[key] == None):
+            deleted_keys.add(key)
 
     # Build query
     query = [f"""MATCH (n:{label}) WHERE n.id = $id """]

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -74,9 +74,20 @@ def update_nodes(label, entry, incomingData):
         if not re.match(r"^\w+$", key) or key == "id":
             raise ValueError("Invalid key: %s", key)
     
-    # Build query
-    query = [f"""MATCH (n:{label}) WHERE n.id = $id """, """SET n={} """, """SET n.id = $id"""]
+    # Get current node information and deleted keys
+    curr_node = list(get_nodes(label, entry).data()[0]['n'].keys())
+    deleted_keys = list(set(curr_node) ^ set(incomingData))
 
+    # Build query
+    query = [f"""MATCH (n:{label}) WHERE n.id = $id """]
+
+    # Delete keys removed by user
+    for key in deleted_keys:
+        if key == "id": # Doesn't require to be deleted
+            continue
+        query.append(f"""\nREMOVE n.{key}\n""")
+
+    # Update keys
     for key in incomingData.keys():
         query.append(f"""\nSET n.{key} = ${key}\n""")
 


### PR DESCRIPTION
### What
- Adds GET paths `/entry/{entry}/parents` and `/entry/{entry}/children` 
- Used for finding parents and children of a node
- Changed neo4j query to disallow partial updates

### Related issue(s)
- Fixes #33 
- Fixes #40 