### PR TITLE
build: Change parser workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,8 @@ name: taxonomy-editor code quality checks and unit tests
 
 on:
   pull_request:
+    paths:
+      - 'parser/**'
 
 jobs:
   # Parser quality


### PR DESCRIPTION
### What
- Parser checks workflow runs for every PR
- It must be run only when any files inside the `parser` directory is changed.