### PR TITLE
fix: Add score > 0 condition for search

### DIFF
--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -251,18 +251,22 @@ def full_text_search(text):
         CALL {
                 CALL db.index.fulltext.queryNodes("nodeSearchIds", $text_id_query_fuzzy)
                 yield node, score as score_
+                where score_ > 0
                 return node, score_ * 3 as score
             UNION
                 CALL db.index.fulltext.queryNodes("nodeSearchTags", $text_query_fuzzy)
                 yield node, score as score_
+                where score_ > 0
                 return node, score_ * 5 as score
             UNION
                 CALL db.index.fulltext.queryNodes("nodeSearchIds", $text_id_query_exact)
                 yield node, score as score_
+                where score_ > 0
                 return node, score_ as score
             UNION
                 CALL db.index.fulltext.queryNodes("nodeSearchTags", $text_query_exact)
                 yield node, score as score_
+                where score_ > 0
                 return node, score_ as score 
         }
         with node.id as node, score


### PR DESCRIPTION
### What
- Neo4J gives a score of 0 for nodes that don't match sometimes
- To account for that, a "where" clause with "score > 0" must be added in the backend
