### PR TITLE
fix: Update requirements.txt for backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ uvicorn==0.18.2
 uvloop==0.16.0
 watchfiles==0.16.0
 websockets==10.3
+Unidecode==1.3.4


### PR DESCRIPTION
### What
- Missing library (Unidecode) in requirements.txt
