### PR TITLE
build: support websocket in dev setup

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -27,6 +27,18 @@ server {
 	# this is the internal Docker DNS, cache only for 30s
     resolver 127.0.0.11 valid=30s;
 
+	# web socket (only for dev)
+	location /ws {
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "Upgrade";
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		set $taxonomy_node taxonomy_node;
+		proxy_pass http://$taxonomy_node:3000/ws;
+	}
+
 	location / {
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
@@ -35,6 +47,7 @@ server {
 		# important do not add a / at the end for node is picky on not having '//' in url
 		proxy_pass http://$taxonomy_node:3000;
 	}
+
 
 }
 

--- a/doc/introduction/setup-dev.md
+++ b/doc/introduction/setup-dev.md
@@ -112,7 +112,7 @@ export REACT_APP_API_URL="http://localhost:8080/"
 npm start
 ```
 
-This should open http://localhost:3000/
+This should open http://localhost:8080/
 
 
 ### Importing some test data

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -14,6 +14,8 @@ services:
         USER_GID: ${USER_GID:-1000}
     environment:
       - REACT_APP_API_URL=//api.${TAXONOMY_EDITOR_DOMAIN}:${TAXONOMY_EDITOR_PORT:-80}/
+      - WDS_SOCKET_HOST=ui.${TAXONOMY_EDITOR_DOMAIN}
+      - WDS_SOCKET_PORT=${TAXONOMY_EDITOR_PORT:-80}
       - TAXONOMY_EDITOR_DOMAIN
       - NODE_ENV=development
       # avoid host check in dev


### PR DESCRIPTION
In dev react tries to open a websocket to the node server (for auto-refresh, I think). This was not supported, now this is.