### PR TITLE
ci: fix API scheme

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,9 @@ TAXONOMY_EDITOR_EXPOSE=127.0.0.1:8091
 # this one is needed only in dev, to tell nginx and fastapi, which port urls should include
 # it must either start with : or be empty
 PUBLIC_TAXONOMY_EDITOR_PORT=:8091
+# API scheme is useful because, in prod, we have to proxy and already proxied request
+# and loose the original scheme
+API_SCHEME=http
 
 # This is the PAT (Personal Access Token)
 # to create PRs on openfoodfacts-server github project (must be able to read-write PRs)

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -139,6 +139,8 @@ jobs:
           echo "TAXONOMY_EDITOR_DOMAIN=${{ env.TAXONOMY_EDITOR_DOMAIN }}" >> .env
           # should be blank in production
           echo "PUBLIC_TAXONOMY_EDITOR_PORT=" >> .env
+          # we use https
+          echo "API_SCHEME=https" >> .env
           # the PAT is environment dependant
           # and must have write access to PRs on the target repo (see REPO_URI)
           echo "GITHUB_PAT=${{ secrets.OFF_SERVER_GITHUB_PAT }}" >> .env

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -96,7 +96,7 @@ server {
 		proxy_set_header Host $host${PUBLIC_TAXONOMY_EDITOR_PORT};
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto ${API_SCHEME};
 		set $taxonomy_api taxonomy_api;
 		proxy_pass http://$taxonomy_api;
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       # taken from .env
       GITHUB_PAT:
       REPO_URI:
+      # make proxy headers be taken into account
+      FORWARDED_ALLOW_IPS: "*"
   taxonomy_frontend:
     # this is the nginx frontend serving react static version or redirecting queries
     image: ghcr.io/openfoodfacts/taxonomy-editor/taxonomy_frontend:${DOCKER_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       DEV_UI_SUFFIX: "-dev"
       TAXONOMY_EDITOR_DOMAIN:
       PUBLIC_TAXONOMY_EDITOR_PORT:
+      API_SCHEME:
     volumes:
       # Nginx, we use templates dir to be able to use environment vars
       - ./conf/nginx.conf:/etc/nginx/templates/default.conf.template


### PR DESCRIPTION
we have to encode API scheme in nginx conf because we are proxying an alrdeay proxied request and loose original scheme.

fixes: https://github.com/openfoodfacts/taxonomy-editor/issues/138
