### PR TITLE
feat: show only some translations in the interface

### DIFF
--- a/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
@@ -26,6 +26,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
     const [nodeObject, setNodeObject] = useState(null); // Storing updates to node
     const [updateChildren, setUpdateChildren] = useState([]); // Storing updates of children in node
     const [open, setOpen] = useState(false); // Used for Dialog component
+    const [shownTranslationLanguages, setShownTranslationLanguages] = useState([]); // Used for storing LC's that are to be shown
 
     // Setting state of node after fetch
     useEffect(() => {
@@ -47,6 +48,12 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
         }
         setNodeObject(duplicateNode);
     }, [node])
+
+    useEffect(() => {
+          // get shown translation languages from local storage
+          const shownTranslationLanguages = JSON.parse(localStorage.getItem('shownTranslationLanguages')) || [];
+          setShownTranslationLanguages(shownTranslationLanguages);
+    }, [])
 
     // Displaying error messages if any
     if (isError) {
@@ -87,6 +94,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
         })).then(() => {
             setOpen(true);
         }).catch(() => {})
+        localStorage.setItem('shownTranslationLanguages', JSON.stringify(shownTranslationLanguages))
     }
     return ( 
         <Box>
@@ -96,7 +104,12 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
                     { !!nodeObject &&
                         <>  <ListEntryParents url={url+'/parents'} urlPrefix={urlPrefix} />
                             <ListEntryChildren url={url+'/children'} urlPrefix={urlPrefix} setUpdateNodeChildren={setUpdateChildren} />
-                            <ListTranslations nodeObject={nodeObject} setNodeObject={setNodeObject} /> 
+                            <ListTranslations
+                                nodeObject = {nodeObject}
+                                setNodeObject = {setNodeObject}
+                                shownTranslationLanguages = {shownTranslationLanguages}
+                                setShownTranslationLanguages = {setShownTranslationLanguages}
+                            /> 
                             <ListAllEntryProperties nodeObject={nodeObject} setNodeObject={setNodeObject} /> </> }
                 </Box> :
                 <>  <ListAllNonEntryInfo nodeObject={nodeObject} id={id} setNodeObject={setNodeObject} /> </>

--- a/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
@@ -26,7 +26,6 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
     const [nodeObject, setNodeObject] = useState(null); // Storing updates to node
     const [updateChildren, setUpdateChildren] = useState([]); // Storing updates of children in node
     const [open, setOpen] = useState(false); // Used for Dialog component
-    const [shownTranslationLanguages, setShownTranslationLanguages] = useState([]); // Used for storing LC's that are to be shown
 
     // Setting state of node after fetch
     useEffect(() => {
@@ -48,12 +47,6 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
         }
         setNodeObject(duplicateNode);
     }, [node])
-
-    useEffect(() => {
-          // get shown translation languages from local storage
-          const shownTranslationLanguages = JSON.parse(localStorage.getItem('shownTranslationLanguages')) || [];
-          setShownTranslationLanguages(shownTranslationLanguages);
-    }, [])
 
     // Displaying error messages if any
     if (isError) {
@@ -94,7 +87,6 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
         })).then(() => {
             setOpen(true);
         }).catch(() => {})
-        localStorage.setItem('shownTranslationLanguages', JSON.stringify(shownTranslationLanguages))
     }
     return ( 
         <Box>
@@ -104,12 +96,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
                     { !!nodeObject &&
                         <>  <ListEntryParents url={url+'/parents'} urlPrefix={urlPrefix} />
                             <ListEntryChildren url={url+'/children'} urlPrefix={urlPrefix} setUpdateNodeChildren={setUpdateChildren} />
-                            <ListTranslations
-                                nodeObject = {nodeObject}
-                                setNodeObject = {setNodeObject}
-                                shownTranslationLanguages = {shownTranslationLanguages}
-                                setShownTranslationLanguages = {setShownTranslationLanguages}
-                            /> 
+                            <ListTranslations nodeObject = {nodeObject} setNodeObject = {setNodeObject} /> 
                             <ListAllEntryProperties nodeObject={nodeObject} setNodeObject={setNodeObject} /> </> }
                 </Box> :
                 <>  <ListAllNonEntryInfo nodeObject={nodeObject} id={id} setNodeObject={setNodeObject} /> </>

--- a/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
@@ -96,7 +96,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
                     { !!nodeObject &&
                         <>  <ListEntryParents url={url+'/parents'} urlPrefix={urlPrefix} />
                             <ListEntryChildren url={url+'/children'} urlPrefix={urlPrefix} setUpdateNodeChildren={setUpdateChildren} />
-                            <ListTranslations nodeObject = {nodeObject} setNodeObject = {setNodeObject} /> 
+                            <ListTranslations nodeObject={nodeObject} setNodeObject={setNodeObject} /> 
                             <ListAllEntryProperties nodeObject={nodeObject} setNodeObject={setNodeObject} /> </> }
                 </Box> :
                 <>  <ListAllNonEntryInfo nodeObject={nodeObject} id={id} setNodeObject={setNodeObject} /> </>

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -7,6 +7,8 @@ import DialogTitle from '@mui/material/DialogTitle';
 import { useEffect, useState } from "react";
 import AddBoxIcon from '@mui/icons-material/AddBox';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import ISO6391 from 'iso-639-1';
 
 /**
@@ -19,6 +21,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
     const [openDialog, setOpen] = useState(false); // Used for Dialog component
     const [newLanguageCode, setNewLanguageCode] = useState(''); // Used for storing new LC from Dialog
     const [isValidLanguageCode, setisValidLanguageCode] = useState(false); // Used for validating a new LC
+    const [shownTranslationLanguages, setShownTranslationLanguages] = useState([]); // Used for storing LC's that are to be shown
 
     // Helper functions for Dialog component
     const handleClose = () => { setOpen(false); }
@@ -27,6 +30,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
     // Used for addition of a translation language
     const handleAddTranslation = (key) => {
         const newRenderedTranslations = [...renderedTranslations, {'languageCode' : key, 'tags' : []}]
+        handleToggleTranslationVisibility(key)
         setRenderedTranslations(newRenderedTranslations);
         key = 'tags_' + key; // LC must have a prefix "tags_"
         const uuidKey = key + '_uuid' // Format for the uuid
@@ -58,9 +62,18 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
         setOpen(false);
     }
 
+    const handleToggleTranslationVisibility = (key) => {
+        const newShownTranslationLanguages = shownTranslationLanguages.includes(key) ? shownTranslationLanguages.filter(obj => !(key === obj)) : [...shownTranslationLanguages, key]
+        setShownTranslationLanguages(newShownTranslationLanguages);
+        localStorage.setItem('shownTranslationLanguages', JSON.stringify(newShownTranslationLanguages));
+    }
+
     // Changes the translations to be rendered
     // Dependent on changes occuring in "nodeObject"
     useEffect(() => {
+        // get shown translation languages from local storage
+        const shownTranslationLanguages = JSON.parse(localStorage.getItem('shownTranslationLanguages')) || [];
+        setShownTranslationLanguages(shownTranslationLanguages);
 
         // Main langauge tags are considered separately, since they have to be rendered first
         const mainLangTags = []
@@ -287,6 +300,9 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                                 <IconButton onClick={() => handleDeleteTranslation(lang)}>
                                     <DeleteOutlineIcon />
                                 </IconButton>
+                                <IconButton onClick={() => handleToggleTranslationVisibility(lang)}>
+                                    {shownTranslationLanguages.includes(lang) ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                                </IconButton>
                             </Stack>
                             {/* Render all related tags */}
                             {
@@ -294,6 +310,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                                     const index = tagObj['index']
                                     const tag = tagObj['tag']
                                     return (
+                                        shownTranslationLanguages.includes(lang) &&
                                         <Stack key={index} sx={{ml: 2}} direction="row" alignItems="center">
                                             <TextField 
                                                 size="small" 

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -21,7 +21,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
     const [newLanguageCode, setNewLanguageCode] = useState(''); // Used for storing new LC from Dialog
     const [languageAction, setLanguageAction] = useState('invalid'); // Used for storing state of action to be performed on LC (add/show/invalid)
     const [shownTranslationLanguages, setShownTranslationLanguages] = useState([]); // Used for storing LC's that are to be shown
-    const [languageOptions, setLanguageOptions] = useState([]); // Used for storing all possible LC's
+    const [addedLanguageCodes, setAddedLanguageCodes] = useState([]); // Used for storing LC's that are added to the nodeObject
 
     // Helper functions for Dialog component
     const handleClose = () => { setOpen(false); }
@@ -119,18 +119,8 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             }
         })
 
-        const languageOptions = []
-        // All language options for add dropdown (already added languages have a 👁 icon)
-        ISO6391.getAllCodes().forEach((languageCode) => {
-            if (addedLanguageCodes.includes(languageCode)) {
-                languageOptions.push(ISO6391.getName(languageCode) + "👁️")
-            }
-            else {
-                languageOptions.push(ISO6391.getName(languageCode))
-            }
-        })
         // Set states
-        setLanguageOptions(languageOptions)
+        setAddedLanguageCodes(addedLanguageCodes);
         setMainLangRenderedTranslations(mainLangTags);
         setRenderedTranslations(otherLangTags);
     }, [nodeObject, shownTranslationLanguages]);
@@ -359,7 +349,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                 </DialogContentText>
                 <Autocomplete
                     sx={{mt: 2}}
-                    options={languageOptions}
+                    options={ISO6391.getAllNames()}
                     onChange={(e,language) => {
                         if (!language) language = '';
                         if (language.includes('👁️')) language = language.slice(0,-3) // exclude the eye emoji for validation
@@ -371,6 +361,16 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                         if (isValidLanguage  && !isDuplicateLanguage) {setLanguageAction("add")}
                         else if (isValidLanguage && !isAlreadyShown && isDuplicateLanguage) {setLanguageAction("show")}
                         else {setLanguageAction("invalid")}
+                    }}
+                    renderOption={(props, option) => {
+                        const languageCode = ISO6391.getCode(option)
+                        const isAlreadyShown = addedLanguageCodes.includes(languageCode)
+                        // set color of text to green if the language is already shown
+                        return (
+                            <span {...props} style={{ color: isAlreadyShown ? 'green' : 'black' }}>
+                                {option}
+                            </span>
+                        )
                     }}
                     renderInput={(params) =>
                         <TextField

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -13,13 +13,14 @@ import ISO6391 from 'iso-639-1';
 /**
  * Sub-component for rendering translation of an "entry"
 */
-const ListTranslations = ({ nodeObject, setNodeObject, shownTranslationLanguages, setShownTranslationLanguages }) => {
+const ListTranslations = ({ nodeObject, setNodeObject }) => {
 
     const [renderedTranslations, setRenderedTranslations] = useState([]) // Stores state of all tags
     const [mainLangRenderedTranslations, setMainLangRenderedTranslations] = useState([]) // Stores state of main language's tags
     const [openDialog, setOpen] = useState(false); // Used for Dialog component
     const [newLanguageCode, setNewLanguageCode] = useState(''); // Used for storing new LC from Dialog
     const [languageAction, setLanguageAction] = useState('invalid'); // Used for storing state of action to be performed on LC (add/show/invalid)
+    const [shownTranslationLanguages, setShownTranslationLanguages] = useState([]); // Used for storing LC's that are to be shown
     const [languageOptions, setLanguageOptions] = useState([]); // Used for storing all possible LC's
 
     // Helper functions for Dialog component
@@ -68,6 +69,7 @@ const ListTranslations = ({ nodeObject, setNodeObject, shownTranslationLanguages
     const handleToggleTranslationVisibility = (key) => {
         const newShownTranslationLanguages = shownTranslationLanguages.includes(key) ? shownTranslationLanguages.filter(obj => !(key === obj)) : [...shownTranslationLanguages, key]
         setShownTranslationLanguages(newShownTranslationLanguages);
+        localStorage.setItem('shownTranslationLanguages', JSON.stringify(newShownTranslationLanguages))
         setOpen(false);
     }
 
@@ -132,6 +134,12 @@ const ListTranslations = ({ nodeObject, setNodeObject, shownTranslationLanguages
         setMainLangRenderedTranslations(mainLangTags);
         setRenderedTranslations(otherLangTags);
     }, [nodeObject, shownTranslationLanguages]);
+
+    useEffect(() => {
+        // get shown translation languages from local storage
+        const shownTranslationLanguages = JSON.parse(localStorage.getItem('shownTranslationLanguages')) || [];
+        setShownTranslationLanguages(shownTranslationLanguages);
+    }, [])
 
     // Helper function used for changing state
     const changeData = (key, index, value) => {

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -339,7 +339,13 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                 } )
             }
             {/* Button to add language to the list of shown languages or show the language if it already exists */}
-            <Button sx={{mt: 2}} onClick={handleOpen}>Add/Show More Languages ({renderedTranslations.length - shownTranslationLanguages.length} Hidden)</Button>
+            <Button sx={{mt: 2}} onClick={handleOpen}>
+                Add/Show More Languages 
+                ({
+                    addedLanguageCodes.length - 
+                    addedLanguageCodes.filter(element => new Set(shownTranslationLanguages).has(element)).length
+                } Hidden)
+            </Button>
             {/* Dialog box for adding languages to the list of shown languages */}
             <Dialog open={openDialog} onClose={handleClose}>
                 <DialogTitle>Add or Show another language</DialogTitle>
@@ -352,7 +358,6 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                     options={ISO6391.getAllNames()}
                     onChange={(e,language) => {
                         if (!language) language = '';
-                        if (language.includes('👁️')) language = language.slice(0,-3) // exclude the eye emoji for validation
                         setNewLanguageCode(ISO6391.getCode(language));
                         const isValidLanguage = ISO6391.validate(ISO6391.getCode(language))
                         const isAlreadyShown = shownTranslationLanguages.includes(ISO6391.getCode(language))

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -74,7 +74,6 @@ const ListTranslations = ({ nodeObject, setNodeObject, shownTranslationLanguages
     // Changes the translations to be rendered
     // Dependent on changes occuring in "nodeObject"
     useEffect(() => {
-        console.log(shownTranslationLanguages)
         // Main langauge tags are considered separately, since they have to be rendered first
         const mainLangTags = []
         const otherLangTags = []
@@ -364,7 +363,6 @@ const ListTranslations = ({ nodeObject, setNodeObject, shownTranslationLanguages
                         if (isValidLanguage  && !isDuplicateLanguage) {setLanguageAction("add")}
                         else if (isValidLanguage && !isAlreadyShown && isDuplicateLanguage) {setLanguageAction("show")}
                         else {setLanguageAction("invalid")}
-                        console.log(isValidLanguage, isAlreadyShown, isDuplicateLanguage, language)
                     }}
                     renderInput={(params) =>
                         <TextField

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -69,8 +69,10 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
     const handleToggleTranslationVisibility = (key) => {
         const newShownTranslationLanguages = shownTranslationLanguages.includes(key) ? shownTranslationLanguages.filter(obj => !(key === obj)) : [...shownTranslationLanguages, key]
         setShownTranslationLanguages(newShownTranslationLanguages);
+        newShownTranslationLanguages.sort()
         localStorage.setItem('shownTranslationLanguages', JSON.stringify(newShownTranslationLanguages))
         setOpen(false);
+        setLanguageAction('invalid')
     }
 
     // Changes the translations to be rendered
@@ -116,6 +118,14 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                         otherLangTags.push(tobeInsertedObj);
                     }
                 }
+            }
+        })
+
+        // add shownTranslationLanguages as a tag to otherLangTags
+        shownTranslationLanguages.forEach((languageCode) => {
+            if (!addedLanguageCodes.includes(languageCode)) {
+                otherLangTags.push({'languageCode' : languageCode, 'tags' : []})
+                addedLanguageCodes.push(languageCode)
             }
         })
 
@@ -182,6 +192,10 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
 
     // Helper function for adding a translation for a LC
     const handleAdd = (key) => {
+        // if key does not exist in nodeObject, add it by addTranslation
+        if (!Object.keys(nodeObject).includes('tags_' + key)) {
+            handleAddTranslation(key);
+        }
         let tagsToBeInserted = [];
         const newUUID = Math.random().toString();
         // State of "MainLangRenderedTranslations" is updated according to format used
@@ -373,7 +387,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                         // set color of text to green if the language is already shown
                         return (
                             <span {...props} style={{ color: isAlreadyShown ? 'green' : 'black' }}>
-                                {option}
+                                {isAlreadyShown ? <b>{option}</b> : option}
                             </span>
                         )
                     }}

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -17,15 +17,16 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
 
     const [renderedTranslations, setRenderedTranslations] = useState([]) // Stores state of all tags
     const [mainLangRenderedTranslations, setMainLangRenderedTranslations] = useState([]) // Stores state of main language's tags
-    const [openDialog, setOpen] = useState(false); // Used for Dialog component
+    const [openDialog, setOpenDialog] = useState(false); // Used for Dialog component
     const [newLanguageCode, setNewLanguageCode] = useState(''); // Used for storing new LC from Dialog
     const [languageAction, setLanguageAction] = useState('invalid'); // Used for storing state of action to be performed on LC (add/show/invalid)
     const [shownTranslationLanguages, setShownTranslationLanguages] = useState([]); // Used for storing LC's that are to be shown
     const [addedLanguageCodes, setAddedLanguageCodes] = useState([]); // Used for storing LC's that are added to the nodeObject
+    const translationVisibilityPreferenceKey = "shownTranslationLanguages" // Used for storing LC's that are to be shown in localStorage
 
     // Helper functions for Dialog component
-    const handleClose = () => { setOpen(false); }
-    const handleOpen = () => { setOpen(true); }
+    const handleClose = () => { setOpenDialog(false); }
+    const handleOpen = () => { setOpenDialog(true); }
 
     // Used for addition of a translation language
     const handleAddTranslation = (key) => {
@@ -45,7 +46,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             newNodeObject[uuidKey] = [Math.random().toString()];
             return newNodeObject
         })
-        setOpen(false);
+        setOpenDialog(false);
     }
 
     // Used for deleting a translation language
@@ -62,16 +63,15 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             delete newNodeObject[uuidKey];
             return newNodeObject
         })
-        setOpen(false);
+        setOpenDialog(false);
     }
 
     // Used for toggling visibility of a translation language
     const handleToggleTranslationVisibility = (key) => {
         const newShownTranslationLanguages = shownTranslationLanguages.includes(key) ? shownTranslationLanguages.filter(obj => !(key === obj)) : [...shownTranslationLanguages, key]
         setShownTranslationLanguages(newShownTranslationLanguages);
-        newShownTranslationLanguages.sort()
-        localStorage.setItem('shownTranslationLanguages', JSON.stringify(newShownTranslationLanguages))
-        setOpen(false);
+        localStorage.setItem(translationVisibilityPreferenceKey, JSON.stringify(newShownTranslationLanguages))
+        setOpenDialog(false);
         setLanguageAction('invalid')
     }
 
@@ -137,8 +137,12 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
 
     useEffect(() => {
         // get shown translation languages from local storage
-        const shownTranslationLanguages = JSON.parse(localStorage.getItem('shownTranslationLanguages')) || [];
-        setShownTranslationLanguages(shownTranslationLanguages);
+        try{
+            const shownTranslationLanguages = JSON.parse(localStorage.getItem(translationVisibilityPreferenceKey)) || []; 
+            setShownTranslationLanguages(shownTranslationLanguages);
+        } catch (e) {
+            console.log(e)
+        }
     }, [])
 
     // Helper function used for changing state
@@ -357,7 +361,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                 Add/Show More Languages 
                 ({
                     addedLanguageCodes.length - 
-                    addedLanguageCodes.filter(element => new Set(shownTranslationLanguages).has(element)).length
+                    addedLanguageCodes.filter(languageCodeItem => shownTranslationLanguages.includes(languageCodeItem)).length
                 } Hidden)
             </Button>
             {/* Dialog box for adding languages to the list of shown languages */}
@@ -383,11 +387,11 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
                     }}
                     renderOption={(props, option) => {
                         const languageCode = ISO6391.getCode(option)
-                        const isAlreadyShown = addedLanguageCodes.includes(languageCode)
+                        const presentInObjectNode = addedLanguageCodes.includes(languageCode)
                         // set color of text to green if the language is already shown
                         return (
-                            <span {...props} style={{ color: isAlreadyShown ? 'green' : 'black' }}>
-                                {isAlreadyShown ? <b>{option}</b> : option}
+                            <span {...props} style={{ color: presentInObjectNode ? 'green' : 'black' }}>
+                                {presentInObjectNode ? <b>{option}</b> : option}
                             </span>
                         )
                     }}


### PR DESCRIPTION
### What
- add visibility toggle to languages
- hide all languages by default
- store user interacted languages in localstorage.

### Screenshot
![visibility_toggle](https://user-images.githubusercontent.com/41837037/210138249-2c4de9d6-8b47-45d0-bd1f-3859f6c4608e.gif)


### Fixes bug(s)
#154 
