### PR TITLE
feat: better UX for saving changes to a taxonomy

### DIFF
--- a/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, Snackbar, Typography } from "@mui/material";
+import { Alert, Box, Snackbar, Typography, Fab } from "@mui/material";
 import { useEffect, useState } from "react";
 import useFetch from "../../components/useFetch";
 import ListEntryParents from "./ListEntryParents";
@@ -7,6 +7,7 @@ import ListTranslations from "./ListTranslations";
 import ListAllEntryProperties from "./ListAllEntryProperties";
 import ListAllNonEntryInfo from "./ListAllNonEntryInfo";
 import { createURL, getIdType } from "./createURL";
+import SaveIcon from '@mui/icons-material/Save';
 
 /**
  * Component used for rendering node information
@@ -24,6 +25,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
     /* eslint no-unused-vars: ["error", { varsIgnorePattern: "^__" }] */
     const { data: node, isPending, isError, __isSuccess, errorMessage } = useFetch(url);
     const [nodeObject, setNodeObject] = useState(null); // Storing updates to node
+    const [changesMade, setChangesMade] = useState(false); // Used to show and hide save FAB
     const [updateChildren, setUpdateChildren] = useState([]); // Storing updates of children in node
     const [open, setOpen] = useState(false); // Used for Dialog component
 
@@ -86,6 +88,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
             })
         })).then(() => {
             setOpen(true);
+            setChangesMade(false);
         }).catch(() => {})
     }
     return ( 
@@ -95,19 +98,34 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
                 <Box>
                     { !!nodeObject &&
                         <>  <ListEntryParents url={url+'/parents'} urlPrefix={urlPrefix} />
-                            <ListEntryChildren url={url+'/children'} urlPrefix={urlPrefix} setUpdateNodeChildren={setUpdateChildren} />
-                            <ListTranslations nodeObject={nodeObject} setNodeObject={setNodeObject} /> 
-                            <ListAllEntryProperties nodeObject={nodeObject} setNodeObject={setNodeObject} /> </> }
+                            <ListEntryChildren 
+                                url={url+'/children'} 
+                                urlPrefix={urlPrefix}
+                                setUpdateNodeChildren={setUpdateChildren} 
+                                setChangesMade={setChangesMade}
+                            />
+                            <ListTranslations nodeObject={nodeObject} setNodeObject={setNodeObject} setChangesMade={setChangesMade} />
+                            <ListAllEntryProperties 
+                                nodeObject={nodeObject} 
+                                setNodeObject={setNodeObject} 
+                                setChangesMade={setChangesMade}     
+                            /> 
+                        </> }
                 </Box> :
                 <>  <ListAllNonEntryInfo nodeObject={nodeObject} id={id} setNodeObject={setNodeObject} /> </>
             }
             {/* Button for submitting edits */}
-            <Button
-                variant="contained"
-                onClick={handleSubmit}
-                sx={{ml: 4, mt:2, width: 130, mb: 2}}>
-                    Submit
-            </Button>
+            { changesMade &&
+                <Fab 
+                    variant="extended"
+                    onClick={handleSubmit}
+                    color="primary" 
+                    sx={{position: 'fixed', bottom: 16, left: 16}}
+                >
+                    <SaveIcon sx={{ mr: 1 }} />
+                    Save Changes
+                </Fab>
+            }
             {/* Snackbar for acknowledgment of update */}
             <Snackbar anchorOrigin={{vertical: 'top', horizontal: 'right'}} open={open} autoHideDuration={3000} onClose={handleClose}>
                 <Alert elevation={6} variant="filled" onClose={handleClose} severity="success">

--- a/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
@@ -2,7 +2,7 @@ import { Box, Grid, Paper, TextField, Typography } from "@mui/material";
 import MaterialTable, { MTableToolbar } from '@material-table/core';
 import { useEffect, useState } from "react";
 
-const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
+const ListAllEntryProperties = ({ nodeObject, setNodeObject, setChangesMade }) => {
     const [data, setData] = useState([]);
 
     // Changes the properties to be rendered
@@ -38,6 +38,7 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
         const newNodeObject = {...nodeObject};
         newNodeObject['preceding_lines'] = value;
         setNodeObject(newNodeObject);
+        setChangesMade(true);
     }
 
     // Helper function used for changing properties of node
@@ -47,6 +48,7 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
             newNodeObject["prop_"+key] = value;
             return newNodeObject 
         })
+        setChangesMade(true);
     }
 
     // Helper function used for deleting properties of node
@@ -56,6 +58,7 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
             const {[toRemove]: _, ...newNodeObject} = prevState;
             return newNodeObject
         })
+        setChangesMade(true);
     }
     
     return (

--- a/taxonomy-editor-frontend/src/pages/editentry/ListEntryChildren.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListEntryChildren.jsx
@@ -14,7 +14,7 @@ import { ENTER_KEYCODE } from "../../constants";
 import { greyHexCode } from "../../constants";
 
 
-const ListEntryChildren = ({url, urlPrefix, setUpdateNodeChildren}) => {
+const ListEntryChildren = ({url, urlPrefix, setUpdateNodeChildren, setChangesMade }) => {
     const [relations, setRelations] = useState(null);
     const [newChild, setNewChild] = useState(null);
     const [newLanguageCode, setNewLanguageCode] = useState(null);
@@ -49,6 +49,7 @@ const ListEntryChildren = ({url, urlPrefix, setUpdateNodeChildren}) => {
             return duplicateData
         });
         setOpenDialog(false);
+        setChangesMade(true);
     }
 
     const handleDeleteChild = (index) => {
@@ -57,6 +58,7 @@ const ListEntryChildren = ({url, urlPrefix, setUpdateNodeChildren}) => {
         // Updated tags assigned for later use
         const tagsToBeInserted = newRelations.map(el => (el.child))
         setUpdateNodeChildren(tagsToBeInserted);
+        setChangesMade(true);
     }
 
     // Check error in fetch

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -12,7 +12,7 @@ import ISO6391 from 'iso-639-1';
 /**
  * Sub-component for rendering translation of an "entry"
 */
-const ListTranslations = ({ nodeObject, setNodeObject }) => {
+const ListTranslations = ({ nodeObject, setNodeObject, setChangesMade }) => {
 
     const [renderedTranslations, setRenderedTranslations] = useState([]) // Stores state of all tags
     const [mainLangRenderedTranslations, setMainLangRenderedTranslations] = useState([]) // Stores state of main language's tags
@@ -39,6 +39,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             return newNodeObject
         })
         setOpen(false);
+        setChangesMade(true);
     }
 
     // Used for deleting a translation language
@@ -56,6 +57,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             return newNodeObject
         })
         setOpen(false);
+        setChangesMade(true);
     }
 
     // Changes the translations to be rendered
@@ -154,6 +156,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             newNodeObject[key] = tagsToBeInserted;
             return newNodeObject 
         })
+        setChangesMade(true);
     }
 
     // Helper function for adding a translation for a LC
@@ -188,6 +191,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             newNodeObject['tags_'+key+'_uuid'].push(newUUID);
             return newNodeObject
         })
+        setChangesMade(true);
     }
 
     const handleDelete = (key, index) => {
@@ -226,6 +230,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
             newNodeObject['tags_'+key+'_uuid'] = newNodeObject['tags_'+key+'_uuid'].filter(currIndex => !(currIndex === index)) 
             return newNodeObject
         })
+        setChangesMade(true);
     }
 
     return (


### PR DESCRIPTION
### What
- Make the save button sticky (convert to FAB to improve accessibility)
- Visual cue for users to tell them they have unsaved changes (FAB only appears after a change is made and disappears on saving)

### Screenshot
![saving](https://user-images.githubusercontent.com/41837037/211842320-7d522379-4c94-42b1-b3e6-42336144e85f.gif)


### Fixes bug(s)
- #162 
