### PR TITLE
feat: hide synonyms and stopwords in the root nodes page

### DIFF
--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -177,7 +177,7 @@ async def find_all_nodes(response: Response, branch: str, taxonomy_name: str):
     return all_nodes
 
 
-@app.get("/{taxonomy_name}/{branch}/rootnodes")
+@app.get("/{taxonomy_name}/{branch}/rootentries")
 async def find_all_root_nodes(response: Response, branch: str, taxonomy_name: str):
     """
     Get all root nodes within taxonomy

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -352,7 +352,11 @@ class TaxonomyGraph:
         Helper function used for getting all root nodes in a taxonomy
         """
         query = f"""
-            MATCH (n:{self.project_name}) WHERE NOT (n)-[:is_child_of]->() RETURN n
+            MATCH (n:{self.project_name})
+            WHERE NOT (n)-[:is_child_of]->()
+            AND NOT (n: STOPWORDS)
+            AND NOT (n: SYNONYMS)
+            RETURN n
         """
         result = get_current_transaction().run(query)
         return result

--- a/taxonomy-editor-frontend/src/pages/allentries/index.jsx
+++ b/taxonomy-editor-frontend/src/pages/allentries/index.jsx
@@ -44,7 +44,7 @@ const Entry = ({ setDisplayedPages }) => {
     isError,
     __isSuccess,
     errorMessage,
-  } = useFetch(`${baseUrl}rootnodes`);
+  } = useFetch(`${baseUrl}rootentries`);
 
   const [nodeType, setNodeType] = useState("entry"); // Used for storing node type
   const [newLanguageCode, setNewLanguageCode] = useState(null); // Used for storing new Language Code


### PR DESCRIPTION
### What
- Exclude synonyms and stopwords from the `/rootnodes` endpoint as we don't support editing them anyway.

### Screenshot
![image](https://user-images.githubusercontent.com/41837037/213649580-c891534f-ed29-44fa-a1b7-565604b46f00.png)

### Fixes bug(s)
- #173 
- Invalidates - #108 
