### PR TITLE
refactor: Removed tags_str property

### DIFF
--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -465,7 +465,7 @@ class TaxonomyGraph:
         # Adding normalized tags ids corresponding to entry tags
         normalised_new_node_keys = {}
         for keys in new_node_keys.keys():
-            if keys.startswith("tags_") and not keys.endswith("_str"):
+            if keys.startswith("tags_"):
                 if "_ids_" not in keys:
                     keys_language_code = keys.split("_", 1)[1]
                     normalised_value = []

--- a/parser/openfoodfacts_taxonomy_parser/parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser.py
@@ -330,7 +330,6 @@ class Parser:
                             # in case 2 normalized synonyms are the same
                             tagsids_list.append(word_normalized)
                     data["tags_" + lang] = tags_list
-                    data["tags_" + lang + "_str"] = " ".join(tags_list)
                     data["tags_ids_" + lang] = tagsids_list
                 else:
                     # property definition
@@ -439,7 +438,7 @@ class Parser:
         self.session.run("".join(query))
 
         language_codes = [lang.alpha2 for lang in list(iso639.languages) if lang.alpha2 != ""]
-        tags_prefixed_lc = ["n.tags_" + lc + "_str" for lc in language_codes]
+        tags_prefixed_lc = ["n.tags_" + lc for lc in language_codes]
         tags_prefixed_lc = ", ".join(tags_prefixed_lc)
         query = f"""CREATE FULLTEXT INDEX {project_name+'_SearchTags'} IF NOT EXISTS
             FOR (n:{project_name}) ON EACH [{tags_prefixed_lc}]"""

--- a/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
@@ -41,8 +41,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
       Object.keys(node[0]).forEach((key) => {
         if (
           key.startsWith("tags") &&
-          !key.includes("ids") &&
-          !key.includes("str")
+          !key.includes("ids")
         ) {
           duplicateNode[key + "_uuid"] = [];
           duplicateNode[key].forEach(() => {

--- a/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/AccumulateAllComponents.jsx
@@ -39,10 +39,7 @@ const AccumulateAllComponents = ({ id, taxonomyName, branchName }) => {
       duplicateNode = { ...node[0] };
       // Adding UUIDs for tags and properties
       Object.keys(node[0]).forEach((key) => {
-        if (
-          key.startsWith("tags") &&
-          !key.includes("ids")
-        ) {
+        if (key.startsWith("tags") && !key.includes("ids")) {
           duplicateNode[key + "_uuid"] = [];
           duplicateNode[key].forEach(() => {
             duplicateNode[key + "_uuid"].push(Math.random().toString());

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -106,10 +106,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
       // Tagids need to be recomputed, so shouldn't be rendered
       // Eg: tags_fr
 
-      if (
-        key.startsWith("tags") &&
-        !key.includes("ids")
-      ) {
+      if (key.startsWith("tags") && !key.includes("ids")) {
         if (key.endsWith("uuid")) {
           const uuids = nodeObject[key];
           // If tags are for main language, add them to mainLangTags

--- a/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListTranslations.jsx
@@ -108,8 +108,7 @@ const ListTranslations = ({ nodeObject, setNodeObject }) => {
 
       if (
         key.startsWith("tags") &&
-        !key.includes("ids") &&
-        !key.includes("str")
+        !key.includes("ids")
       ) {
         if (key.endsWith("uuid")) {
           const uuids = nodeObject[key];


### PR DESCRIPTION
### What
- Removes the tags_str property
- Uses the tags_lc property for creating search indexes

### Related issue(s)
- #219 
