### PR TITLE
refactor(backend): better error handling in backend

### DIFF
--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -138,6 +138,14 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         content=jsonable_encoder({"detail": "Invalid request", "errors": reformatted_errors}),
     )
 
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    """
+    Custom exception handler to log FastAPI exceptions.
+    """
+    # Log the detail message
+    log.info(f" ERROR: {exc.detail}")
+    return JSONResponse(status_code=exc.status_code, content={"message": exc.detail})
 
 # Get methods
 

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -24,6 +24,7 @@ from fastapi import (
     status,
 )
 from fastapi.encoders import jsonable_encoder
+from fastapi.exception_handlers import http_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
@@ -111,7 +112,7 @@ def file_cleanup(filepath):
     try:
         os.remove(filepath)
     except FileNotFoundError:
-             log.warn(f"Taxonomy file {filepath} not found for deletion")
+        log.warn(f"Taxonomy file {filepath} not found for deletion")
 
 
 class StatusFilter(str, Enum):
@@ -140,14 +141,13 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 
 @app.exception_handler(HTTPException)
-async def http_exception_handler(request: Request, exc: HTTPException):
+async def log_http_exception(request: Request, exc: HTTPException):
     """
     Custom exception handler to log FastAPI exceptions.
     """
     # Log the detail message
     log.info(f" ERROR: {exc.detail}")
-    return JSONResponse(status_code=exc.status_code, content={"message": exc.detail})
-    # return await http_exception_handler(request, exc)
+    return await http_exception_handler(request, exc)
 
 
 # Get methods

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -138,6 +138,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         content=jsonable_encoder({"detail": "Invalid request", "errors": reformatted_errors}),
     )
 
+
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException):
     """

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -101,7 +101,7 @@ def check_single(id):
     if len(id) == 0:
         raise HTTPException(status_code=404, detail="Entry not found")
     elif len(id) > 1:
-        raise HTTPException(status_code=409, detail="Multiple entries found")
+        raise HTTPException(status_code=500, detail="Multiple entries found")
 
 
 def file_cleanup(filepath):
@@ -110,8 +110,8 @@ def file_cleanup(filepath):
     """
     try:
         os.remove(filepath)
-    except Exception as e:
-        raise HTTPException(status_code=404, detail="Taxonomy file not found for deletion") from e
+    except FileNotFoundError:
+             log.warn(f"Taxonomy file {filepath} not found for deletion")
 
 
 class StatusFilter(str, Enum):
@@ -147,6 +147,7 @@ async def http_exception_handler(request: Request, exc: HTTPException):
     # Log the detail message
     log.info(f" ERROR: {exc.detail}")
     return JSONResponse(status_code=exc.status_code, content={"message": exc.detail})
+    # return await http_exception_handler(request, exc)
 
 
 # Get methods

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -148,6 +148,7 @@ async def http_exception_handler(request: Request, exc: HTTPException):
     log.info(f" ERROR: {exc.detail}")
     return JSONResponse(status_code=exc.status_code, content={"message": exc.detail})
 
+
 # Get methods
 
 

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -101,7 +101,7 @@ def check_single(id):
     if len(id) == 0:
         raise HTTPException(status_code=404, detail="Entry not found")
     elif len(id) > 1:
-        raise HTTPException(status_code=500, detail="Multiple entries found")
+        raise HTTPException(status_code=409, detail="Multiple entries found")
 
 
 def file_cleanup(filepath):
@@ -111,7 +111,7 @@ def file_cleanup(filepath):
     try:
         os.remove(filepath)
     except Exception as e:
-        raise HTTPException(status_code=500, detail="Taxonomy file not found for deletion") from e
+        raise HTTPException(status_code=404, detail="Taxonomy file not found for deletion") from e
 
 
 class StatusFilter(str, Enum):
@@ -351,10 +351,10 @@ async def export_to_github(
         return url
 
     except GithubBranchExistsError:
-        raise HTTPException(status_code=500, detail="The Github branch already exists!")
+        raise HTTPException(status_code=409, detail="The Github branch already exists!")
 
     except GithubUploadError:
-        raise HTTPException(status_code=500, detail="Github upload error!")
+        raise HTTPException(status_code=400, detail="Github upload error!")
 
 
 # Post methods
@@ -370,7 +370,7 @@ async def import_from_github(request: Request, branch: str, taxonomy_name: str):
 
     taxonomy = TaxonomyGraph(branch, taxonomy_name)
     if not taxonomy.is_valid_branch_name():
-        raise HTTPException(status_code=400, detail="branch_name: Enter a valid branch name!")
+        raise HTTPException(status_code=422, detail="branch_name: Enter a valid branch name!")
     if await taxonomy.does_project_exist():
         raise HTTPException(status_code=409, detail="Project already exists!")
     if not await taxonomy.is_branch_unique():
@@ -390,7 +390,7 @@ async def upload_taxonomy(
     # use the file name as the taxonomy name
     taxonomy = TaxonomyGraph(branch, taxonomy_name)
     if not taxonomy.is_valid_branch_name():
-        raise HTTPException(status_code=400, detail="branch_name: Enter a valid branch name!")
+        raise HTTPException(status_code=422, detail="branch_name: Enter a valid branch name!")
     if await taxonomy.does_project_exist():
         raise HTTPException(status_code=409, detail="Project already exists!")
     if not await taxonomy.is_branch_unique():

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -5,6 +5,10 @@ from textwrap import dedent
 
 from github import Github, GithubException
 
+from fastapi import (
+    HTTPException,
+)
+
 from . import settings
 
 
@@ -23,10 +27,10 @@ class GithubOperations:
         """
         access_token = settings.access_token
         if not access_token:
-            raise Exception("Access token is not set. Please add your access token in .env")
+            raise Exception(status_code=400, detail="Access token is not set. Please add your access token in .env")
         repo_uri = settings.repo_uri
         if not repo_uri:
-            raise Exception("repo_uri is not set. Please add your access token in .env")
+            raise Exception(status_code=400, detail="repo_uri is not set. Please add your access token in .env")
         github_driver = Github(access_token)
         repo = github_driver.get_repo(repo_uri)
         return repo

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -3,11 +3,8 @@ Github helper functions for the Taxonomy Editor API
 """
 from textwrap import dedent
 
+from fastapi import HTTPException
 from github import Github, GithubException
-
-from fastapi import (
-    HTTPException,
-)
 
 from . import settings
 
@@ -29,13 +26,12 @@ class GithubOperations:
         if not access_token:
             raise HTTPException(
                 status_code=400,
-                detail="Access token is not set. Please add your access token in .env"
+                detail="Access token is not set. Please add your access token in .env",
             )
         repo_uri = settings.repo_uri
         if not repo_uri:
             raise HTTPException(
-                status_code=400,
-                detail="repo_uri is not set. Please add your access token in .env"
+                status_code=400, detail="repo_uri is not set. Please add your access token in .env"
             )
         github_driver = Github(access_token)
         repo = github_driver.get_repo(repo_uri)

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -27,10 +27,16 @@ class GithubOperations:
         """
         access_token = settings.access_token
         if not access_token:
-            raise HTTPException(status_code=400, detail="Access token is not set. Please add your access token in .env")
+            raise HTTPException(
+                status_code=400,
+                detail="Access token is not set. Please add your access token in .env"
+            )
         repo_uri = settings.repo_uri
         if not repo_uri:
-            raise HTTPException(status_code=400, detail="repo_uri is not set. Please add your access token in .env")
+            raise HTTPException(
+                status_code=400,
+                detail="repo_uri is not set. Please add your access token in .env"
+            )
         github_driver = Github(access_token)
         repo = github_driver.get_repo(repo_uri)
         return repo

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -27,10 +27,10 @@ class GithubOperations:
         """
         access_token = settings.access_token
         if not access_token:
-            raise Exception(status_code=400, detail="Access token is not set. Please add your access token in .env")
+            raise HTTPException(status_code=400, detail="Access token is not set. Please add your access token in .env")
         repo_uri = settings.repo_uri
         if not repo_uri:
-            raise Exception(status_code=400, detail="repo_uri is not set. Please add your access token in .env")
+            raise HTTPException(status_code=400, detail="repo_uri is not set. Please add your access token in .env")
         github_driver = Github(access_token)
         repo = github_driver.get_repo(repo_uri)
         return repo

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -74,13 +74,13 @@ class GithubOperations:
             )
         except GithubException as e:
             # Handle GitHub API-related exceptions
-            raise Exception(f"GitHub API error: {e}")
-        except FileNotFoundError:
+            raise Exception(f"GitHub API error: {e}") from e
+        except FileNotFoundError as e:
             # Handle file not found error (e.g., when 'filename' does not exist)
-            raise Exception(f"File not found: {filename}")
+            raise Exception(f"File not found: {filename}") from e
         except Exception as e:
             # Handle any other unexpected exceptions
-            raise Exception(f"An error occurred: {e}")
+            raise Exception(f"An error occurred: {e}") from e
 
     def create_pr(self, description):
         """


### PR DESCRIPTION
Add specific messages if Github settings were not added and change some status codes in backend

### What
Some errors raised by backend have a 500 status code intead of having 4XX error.
For example, if a developer forgets to add a Personal Access Token and wants to import a project to edit, the server throws a 500 error instead of 400 error.

### Screenshot
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/e0c24f5a-9de7-47b1-a31b-20741729df8b)

### Fixes bug(s)

### Part of 
- backend/editor
