### PR TITLE
fix(taxonomy-editor-frontend): redirect user to node editor when clicking from nodes page

### DIFF
--- a/taxonomy-editor-frontend/src/pages/root-nodes/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/root-nodes/index.tsx
@@ -153,7 +153,7 @@ const RootNodes = ({
                   <TableCell align="left" component="td" scope="row">
                     <IconButton
                       component={Link}
-                      to={`${node[0].id}`}
+                      to={`/${taxonomyName}/${branchName}/entry/${node[0].id}`}
                       aria-label="edit"
                     >
                       <EditIcon color="primary" />


### PR DESCRIPTION
### What
User can not choose a node to edit from Nodes page.
To do that, has to go to Search page and click on it. 

### Screenshot
Go to https://ui.taxonomy.openfoodfacts.net/states/editstostates/entry
And try to click on an edit button (nothing happens)

### Fixes bug(s)
Now, on Nodes page, user can click on an edit button to go to node editor.

### Part of 
taxonomy-editor-frontend
