### PR TITLE
refactor(backend,taxonomy-editor-frontend): Handle background task on frontend

### DIFF
--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -372,7 +372,9 @@ async def export_to_github(
 
 
 @app.post("/{taxonomy_name}/{branch}/import")
-async def import_from_github(request: Request, branch: str, taxonomy_name: str,background_tasks: BackgroundTasks):
+async def import_from_github(
+    request: Request, branch: str, taxonomy_name: str, background_tasks: BackgroundTasks
+):
     """
     Get taxonomy from Product Opener GitHub repository
     """

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -82,7 +82,7 @@ async def shutdown():
     """
     Shutdown database
     """
-    graph_db.shutdown_db()
+    await graph_db.shutdown_db()
 
 
 @app.middleware("http")
@@ -389,8 +389,8 @@ async def import_from_github(
     if not await taxonomy.is_branch_unique():
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    background_tasks.add_task(taxonomy.import_from_github, description)
-    return {"message": "Parsing sent in the background"}
+    status = await taxonomy.import_from_github(description,background_tasks)
+    return status
 
 
 @app.post("/{taxonomy_name}/{branch}/upload")

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -382,6 +382,7 @@ async def import_from_github(
     description = incoming_data["description"]
 
     taxonomy = TaxonomyGraph(branch, taxonomy_name)
+
     if not taxonomy.is_valid_branch_name():
         raise HTTPException(status_code=422, detail="branch_name: Enter a valid branch name!")
     if await taxonomy.does_project_exist():
@@ -389,7 +390,7 @@ async def import_from_github(
     if not await taxonomy.is_branch_unique():
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    status = await taxonomy.import_from_github(description,background_tasks)
+    status = await taxonomy.import_from_github(description, background_tasks)
     return status
 
 

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -372,7 +372,7 @@ async def export_to_github(
 
 
 @app.post("/{taxonomy_name}/{branch}/import")
-async def import_from_github(request: Request, branch: str, taxonomy_name: str):
+async def import_from_github(request: Request, branch: str, taxonomy_name: str,background_tasks: BackgroundTasks):
     """
     Get taxonomy from Product Opener GitHub repository
     """
@@ -387,8 +387,8 @@ async def import_from_github(request: Request, branch: str, taxonomy_name: str):
     if not await taxonomy.is_branch_unique():
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    result = await taxonomy.import_from_github(description)
-    return result
+    background_tasks.add_task(await taxonomy.import_from_github(description))
+    return {"message": "Parsing sending in the background"}
 
 
 @app.post("/{taxonomy_name}/{branch}/upload")

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -390,7 +390,7 @@ async def import_from_github(
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
     background_tasks.add_task(await taxonomy.import_from_github(description))
-    return {"message": "Parsing sending in the background"}
+    return {"message": "Parsing sent in the background"}
 
 
 @app.post("/{taxonomy_name}/{branch}/upload")

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -389,7 +389,7 @@ async def import_from_github(
     if not await taxonomy.is_branch_unique():
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    background_tasks.add_task(await taxonomy.import_from_github(description))
+    background_tasks.add_task(taxonomy.import_from_github, description)
     return {"message": "Parsing sent in the background"}
 
 

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -3,8 +3,6 @@ Taxonomy Editor Backend API
 """
 import logging
 import os
-import shutil
-import tempfile
 
 # Required imports
 # ------------------------------------------------------------------------------------#
@@ -396,7 +394,11 @@ async def import_from_github(
 
 @app.post("/{taxonomy_name}/{branch}/upload")
 async def upload_taxonomy(
-    branch: str, taxonomy_name: str, file: UploadFile, description: str = Form(...)
+    branch: str,
+    taxonomy_name: str,
+    file: UploadFile,
+    background_tasks: BackgroundTasks,
+    description: str = Form(...),
 ):
     """
     Upload taxonomy file to be parsed
@@ -409,11 +411,7 @@ async def upload_taxonomy(
     if not await taxonomy.is_branch_unique():
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    with tempfile.TemporaryDirectory(prefix="taxonomy-") as tmpdir:
-        filepath = f"{tmpdir}/{file.filename}"
-        with open(filepath, "wb") as f:
-            shutil.copyfileobj(file.file, f)
-        result = await taxonomy.upload_taxonomy(filepath, description)
+    result = await taxonomy.upload_taxonomy(file, description, background_tasks)
 
     return result
 

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -120,6 +120,8 @@ class StatusFilter(str, Enum):
 
     OPEN = "OPEN"
     CLOSED = "CLOSED"
+    LOADING = "LOADING"
+    FAILED = "FAILED"
 
 
 @app.exception_handler(RequestValidationError)

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -87,7 +87,8 @@ class TaxonomyGraph:
         Helper function to call the Open Food Facts Python Taxonomy Parser
         """
         # Close current transaction to use the session variable in parser
-        await get_current_transaction().commit()
+        async with get_current_transaction() as transaction:
+            transaction.commit()
 
         with SyncTransactionCtx() as session:
             # Create parser object and pass current session to it

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -86,10 +86,6 @@ class TaxonomyGraph:
         """
         Helper function to call the Open Food Facts Python Taxonomy Parser
         """
-        # Close current transaction to use the session variable in parser
-        async with get_current_transaction() as transaction:
-            transaction.commit()
-
         with SyncTransactionCtx() as session:
             # Create parser object and pass current session to it
             parser_object = parser.Parser(session)

--- a/backend/editor/graph_db.py
+++ b/backend/editor/graph_db.py
@@ -49,11 +49,11 @@ def initialize_db():
     driver = neo4j.AsyncGraphDatabase.driver(uri)
 
 
-def shutdown_db():
+async def shutdown_db():
     """
     Close session and driver of Neo4J database
     """
-    driver.close()
+    await driver.close()
 
 
 def get_current_transaction():
@@ -85,6 +85,6 @@ def SyncTransactionCtx():
     Normally it should be reserved to background tasks
     """
     uri = settings.uri
-    driver = neo4j.GraphDatabase.driver(uri)
-    with driver.session() as _session:
-        yield _session
+    with neo4j.GraphDatabase.driver(uri) as driverSync:
+        with driverSync.session() as _session:
+            yield _session

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -52,7 +52,8 @@ def test_import_from_github(client, github_mock, mocker):
     )
 
     assert response.status_code == 200
-    assert response.json()["message"] == "Parsing sent in the background"
+    # assert response.json()["message"] == "Parsing sent in the background"
+    assert response.json() is True
 
 
 def test_upload_taxonomy(client, github_mock):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -52,7 +52,6 @@ def test_import_from_github(client, github_mock, mocker):
     )
 
     assert response.status_code == 200
-    # assert response.json()["message"] == "Parsing sent in the background"
     assert response.json() is True
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -52,7 +52,7 @@ def test_import_from_github(client, github_mock, mocker):
     )
 
     assert response.status_code == 200
-    assert response.json() is True
+    assert response.json()["message"] == "Parsing sent in the background"
 
 
 def test_upload_taxonomy(client, github_mock):

--- a/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
@@ -29,7 +29,7 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
   const navigate = useNavigate();
 
   const { data, isPending, isError } = useFetch<ProjectsAPIResponse>(
-    `${API_URL}projects?status=OPEN`
+    `${API_URL}projects`
   );
 
   useEffect(() => {
@@ -37,7 +37,14 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
 
     if (data) {
       const backendProjects = data.map(
-        ({ id, branch_name, taxonomy_name, description, errors_count }) => {
+        ({
+          id,
+          branch_name,
+          taxonomy_name,
+          description,
+          errors_count,
+          status,
+        }) => {
           return {
             id, // needed by MaterialTable as key
             projectName: id,
@@ -45,6 +52,7 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
             branchName: branch_name,
             description: description,
             errors_count: errors_count,
+            status: status,
           };
         }
       );
@@ -117,6 +125,7 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
                 }
               },
             },
+            { title: "Status", field: "status" },
           ]}
           options={{
             actionsColumnIndex: -1,

--- a/taxonomy-editor-frontend/src/pages/root-nodes/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/root-nodes/index.tsx
@@ -84,7 +84,7 @@ const RootNodes = ({
     );
   }
 
-  if (isPending || !nodes) {
+  if (isPending || !nodes || nodes.length === 0) {
     return (
       <Box
         sx={{
@@ -93,6 +93,12 @@ const RootNodes = ({
         }}
       >
         <CircularProgress />
+        <Typography sx={{ m: 5 }} variant="h6">
+          Taxonomy parsing may take several minutes, depending on the complexity
+          of the taxonomy being imported.
+          <br />
+          Kindly refresh the page to view the updated status of the project.
+        </Typography>
       </Box>
     );
   }

--- a/taxonomy-editor-frontend/src/pages/startproject/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/startproject/index.tsx
@@ -42,6 +42,7 @@ const StartProject = ({ clearNavBarLinks }) => {
     const baseUrl = createBaseURL(toSnakeCase(taxonomyName), branchName);
     setLoading(true);
     const dataToBeSent = { description: description };
+    let errorMessage: string = "Unable to import";
 
     fetch(`${baseUrl}import`, {
       method: "POST",
@@ -51,12 +52,13 @@ const StartProject = ({ clearNavBarLinks }) => {
       .then(async (response) => {
         const responseBody = await response.json();
         if (!response.ok) {
-          throw new Error(responseBody?.detail ?? "Unable to import");
+          errorMessage = responseBody?.detail ?? "Unable to import";
+          throw new Error(errorMessage);
         }
         navigate(`/${toSnakeCase(taxonomyName)}/${branchName}/entry`);
       })
       .catch(() => {
-        setErrorMessage("Unable to import");
+        setErrorMessage(errorMessage);
       })
       .finally(() => setLoading(false));
   };


### PR DESCRIPTION
### Current situation
- If parsing takes too long, the frontend times out, resulting in a timeout notification : 

![Image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/6abf6d44-6f9b-41ae-a05b-fd80a99f1762)

- Only successfully parsed taxonomies are displayed in the existing projects list. Failed or loading taxonomies are not visible.

### To be done 

- [x] Project Creation Page: Users should land on a loading page upon creating a project, prompting them to refresh the page for updates
- [x] Projects Listing: Ensure all projects are visible in the table, including those that failed or are still loading
- [x]  ¨Project Status: Display project statuses (successfully parsed, parsing failed, parsing in progress) in the projects list

These enhancements will offer a more comprehensive view of project statuses, provide clarity to users during parsing, and ensure visibility of all projects in the list, even if parsing fails or takes longer than expected.

### Screenshot
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/4185de45-7f39-460a-8ec1-574b16395c76)
A small text reminds user to reload the page to see taxonomy

![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/8d1697d0-8f93-471d-8447-4e21642ceac3)
In the list, the project status is displayed.
Not only the open projects are listed but also the other ones.

### Part of 
(https://github.com/orgs/openfoodfacts/projects/103/views/1?pane=issue&itemId=46878339)
