### PR TITLE
feat: Add parent order determinism

### DIFF
--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -416,6 +416,7 @@ class TaxonomyGraph:
             MATCH (child_node:{self.project_name}:ENTRY)-[r:is_child_of]->(parent)
                 WHERE child_node.id = $id
             RETURN parent.id
+            ORDER BY r.position
         """
         query_result = await get_current_transaction().run(query, {"id": entry})
         return [item async for result_list in query_result for item in result_list]

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -536,7 +536,8 @@ class TaxonomyGraph:
         for child_id in children_ids:
             # Create new relationships if it doesn't exist
             query = f"""
-                MATCH ()-[r:is_child_of]->(parent:{self.project_name}:ENTRY), (new_child:{self.project_name}:ENTRY)
+                MATCH ()-[r:is_child_of]->(parent:{self.project_name}:ENTRY),
+                (new_child:{self.project_name}:ENTRY)
                 WHERE parent.id = $id AND new_child.id = $child_id
                 WITH parent, new_child, COUNT(r) AS rel_count
                 MERGE (new_child)-[r:is_child_of]->(parent)

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -536,9 +536,11 @@ class TaxonomyGraph:
         for child_id in children_ids:
             # Create new relationships if it doesn't exist
             query = f"""
-                MATCH (parent:{self.project_name}:ENTRY), (new_child:{self.project_name}:ENTRY)
+                MATCH ()-[r:is_child_of]->(parent:{self.project_name}:ENTRY), (new_child:{self.project_name}:ENTRY)
                 WHERE parent.id = $id AND new_child.id = $child_id
+                WITH parent, new_child, COUNT(r) AS rel_count
                 MERGE (new_child)-[r:is_child_of]->(parent)
+                ON CREATE SET r.position = rel_count
             """
             _result = await get_current_transaction().run(
                 query, {"id": entry, "child_id": child_id}

--- a/parser/openfoodfacts_taxonomy_parser/parser/parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser/parser.py
@@ -151,17 +151,21 @@ class Parser:
                 unnormalised_child_links.append(child_link)
 
         # adding normalised links is easy as we can directly match parent entries
-        normalised_query = f"""
-            UNWIND $normalised_child_links as child_link
-            MATCH (p:{project_label}) USING INDEX p:{project_label}(id)
-            WHERE p.id = child_link.parent_id
-            MATCH (c:{project_label}) USING INDEX c:{project_label}(id)
-            WHERE c.id = child_link.id
-            CREATE (c)-[relations:is_child_of]->(p)
-            WITH relations
-            UNWIND relations AS relation
-            RETURN COUNT(relation)
-        """
+        normalised_query = (
+            f"""
+                UNWIND $normalised_child_links as child_link
+                MATCH (p:{project_label}) USING INDEX p:{project_label}(id)
+                WHERE p.id = child_link.parent_id
+                MATCH (c:{project_label}) USING INDEX c:{project_label}(id)
+            """
+            + """
+                WHERE c.id = child_link.id
+                CREATE (c)-[relations:is_child_of {position: child_link.position}]->(p)
+                WITH relations
+                UNWIND relations AS relation
+                RETURN COUNT(relation)
+            """
+        )
 
         # for unnormalised links, we need to group them by language code of the parent id
         lc_child_links_map = collections.defaultdict(list)
@@ -173,17 +177,21 @@ class Parser:
         # we create a query for each language code
         lc_queries = []
         for lc, lc_child_links in lc_child_links_map.items():
-            lc_query = f"""
-                UNWIND $lc_child_links as child_link
-                MATCH (p:{project_label})
-                WHERE child_link.parent_id IN p.tags_ids_{lc}
-                MATCH (c:{project_label}) USING INDEX c:{project_label}(id)
-                WHERE c.id = child_link.id
-                CREATE (c)-[relations:is_child_of]->(p)
-                WITH relations
-                UNWIND relations AS relation
-                RETURN COUNT(relation)
-            """
+            lc_query = (
+                f"""
+                    UNWIND $lc_child_links as child_link
+                    MATCH (p:{project_label})
+                    WHERE child_link.parent_id IN p.tags_ids_{lc}
+                    MATCH (c:{project_label}) USING INDEX c:{project_label}(id)
+                """
+                + """
+                    WHERE c.id = child_link.id
+                    CREATE (c)-[relations:is_child_of {position: child_link.position}]->(p)
+                    WITH relations
+                    UNWIND relations AS relation
+                    RETURN COUNT(relation)
+                """
+            )
             lc_queries.append((lc_query, lc_child_links))
 
         count = 0

--- a/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
@@ -58,6 +58,7 @@ class PreviousLink(TypedDict):
 class ChildLink(TypedDict):
     parent_id: str
     id: str
+    position: int
 
 
 @dataclass(slots=True)
@@ -341,8 +342,8 @@ class TaxonomyParser:
             if entry.is_before:
                 previous_links.append(PreviousLink(before_id=entry.is_before, id=entry.id))
             if entry.parent_tag:
-                for parent in entry.parent_tag:
-                    child_links.append(ChildLink(parent_id=parent, id=entry.id))
+                for position, parent in enumerate(entry.parent_tag):
+                    child_links.append(ChildLink(parent_id=parent, id=entry.id, position=position))
         return Taxonomy(
             entry_nodes=entry_nodes,
             other_nodes=other_nodes,

--- a/parser/openfoodfacts_taxonomy_parser/unparser.py
+++ b/parser/openfoodfacts_taxonomy_parser/unparser.py
@@ -28,6 +28,10 @@ class WriteTaxonomy:
     def get_all_nodes(self, multi_label):
         """query the database and yield each node with its parents,
         this function use the relationships between nodes"""
+        # This query first lists all the nodes in the "is_before" order
+        # then for each node in the path, it finds its parents
+        # and finally it returns the node and its parents (the parents are ordered in the same order as in the original file)
+        # Note: OPTIONAL MATCH is used to return nodes without parents
         query = f"""
             MATCH path = ShortestPath(
                 (h:{multi_label}:TEXT)-[:is_before*]->(f:{multi_label}:TEXT)

--- a/parser/openfoodfacts_taxonomy_parser/unparser.py
+++ b/parser/openfoodfacts_taxonomy_parser/unparser.py
@@ -33,8 +33,12 @@ class WriteTaxonomy:
                 (h:{multi_label}:TEXT)-[:is_before*]->(f:{multi_label}:TEXT)
             )
             WHERE h.id="__header__" AND f.id="__footer__"
-            UNWIND nodes(path) AS n
-            RETURN n , [(n)-[:is_child_of]->(m) | m ]
+            WITH nodes(path) AS nodes, range(0, size(nodes(path))-1) AS indexes
+            UNWIND indexes AS index
+            WITH nodes[index] AS n, index
+            OPTIONAL MATCH (n)-[r:is_child_of]->(parent)
+            WITH n, r, parent ORDER BY index, r.position
+            RETURN n, collect(parent)
         """
         results = self.session.run(query)
         for result in results:

--- a/parser/tests/integration/test_parse_unparse_integration.py
+++ b/parser/tests/integration/test_parse_unparse_integration.py
@@ -60,11 +60,6 @@ def test_round_trip(neo4j):
         # second tweak: renaming parent
         elif line.startswith("<fr:yaourts fruit de la passion"):
             line = "<en:Passion fruit yogurts"
-        # last tweak: parent order
-        elif line.startswith("<en:fake-stuff"):
-            line = "<en:fake-meat"
-        elif line.startswith("<en:fake-meat"):
-            line = "<en:fake-stuff"
         expected_lines.append(line)
 
     assert expected_lines == lines
@@ -107,11 +102,6 @@ def test_two_branch_round_trip(neo4j):
         # second tweak: renaming parent
         elif line.startswith("<fr:yaourts fruit de la passion"):
             line = "<en:Passion fruit yogurts"
-        # last tweak: parent order
-        elif line.startswith("<en:fake-stuff"):
-            line = "<en:fake-meat"
-        elif line.startswith("<en:fake-meat"):
-            line = "<en:fake-stuff"
         expected_lines.append(line)
 
     assert expected_lines == lines_branch1


### PR DESCRIPTION
### What
Currently, when we export back the taxonomy to a .txt file, the parent order is random and not deterministic
To solve this, we are now keeping track of the parent order in the original file
In the future, we may want to impose the parent order (alphabetical order for example) but right now, it would result in too big .txt file diff

### Fixes bug(s)
https://github.com/orgs/openfoodfacts/projects/103/views/1?pane=issue&itemId=48206861
