### PR TITLE
fix(frontend): Enhance Edition of Properties for a Node

### DIFF
--- a/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
@@ -99,14 +99,25 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
               }),
             onRowDelete: (selectedRow) =>
               new Promise((resolve, reject) => {
-                // Delete property from rendered rows
-                const index = selectedRow.tableData.id;
-                const updatedRows = data.filter((obj) => !(index === obj.id));
-                setData(updatedRows);
+                try {
+                  console.log("I want to delete this property : ",selectedRow.propertyName)
+                  // Delete property from rendered rows
+                  const updatedRows = [...data];
+                  console.log(selectedRow.tableData)
+                  // const index = selectedRow.tableData.id;
+                  const index = selectedRow.id;
+                  // const updatedRows = data.filter((obj) => !(index === obj.id));
+                  updatedRows.splice(index,1);
+                  setData([...updatedRows]);
+                  console.log("updated Rows = ",updatedRows);
+                  console.log("New data = ", data);
 
-                // Delete key-value pair of a property from nodeObject
-                deletePropertyData(selectedRow.propertyName);
-                resolve();
+                  // Delete key-value pair of a property from nodeObject
+                  deletePropertyData(selectedRow.propertyName);
+                  resolve();
+                } catch (error) {
+                  console.log(error);
+                }
               }),
             onRowUpdate: (updatedRow, oldRow) =>
               new Promise((resolve, reject) => {

--- a/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
@@ -74,7 +74,7 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
       />
 
       {/* Properties */}
-      <Box sx={{ width: "50%", ml: 4 }}>
+      <Box sx={{ width: "90%", ml: 4, maxWidth: "1000px", m: "auto" }}>
         <MaterialTable
           data={data}
           columns={[
@@ -129,6 +129,8 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
           options={{
             actionsColumnIndex: -1,
             addRowPosition: "last",
+            tableLayout: "fixed",
+            paging: false,
           }}
           components={{
             Toolbar: (props) => {

--- a/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
@@ -1,13 +1,10 @@
 import { Box, Grid, Paper, TextField, Typography } from "@mui/material";
 import MaterialTable, { MTableToolbar } from "@material-table/core";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
-  const [data, setData] = useState([]);
-
-  // Changes the properties to be rendered
-  // Dependent on changes occuring in "nodeObject"
-  useEffect(() => {
+  
+  const collectProperties = () => {
     let renderedProperties = [];
     Object.keys(nodeObject).forEach((key) => {
       // Collecting uuids of properties
@@ -30,8 +27,10 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
         });
       }
     });
-    setData(renderedProperties);
-  }, [nodeObject]);
+    return renderedProperties;
+  };
+
+  const [data, setData] = useState(collectProperties());
 
   // Helper function used for changing comments from node
   const changeCommentData = (value) => {
@@ -99,25 +98,15 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
               }),
             onRowDelete: (selectedRow) =>
               new Promise((resolve, reject) => {
-                try {
-                  console.log("I want to delete this property : ",selectedRow.propertyName)
                   // Delete property from rendered rows
                   const updatedRows = [...data];
-                  console.log(selectedRow.tableData)
-                  // const index = selectedRow.tableData.id;
                   const index = selectedRow.id;
-                  // const updatedRows = data.filter((obj) => !(index === obj.id));
-                  updatedRows.splice(index,1);
-                  setData([...updatedRows]);
-                  console.log("updated Rows = ",updatedRows);
-                  console.log("New data = ", data);
+                  updatedRows.splice(index, 1);
+                  setData(updatedRows);
 
                   // Delete key-value pair of a property from nodeObject
                   deletePropertyData(selectedRow.propertyName);
                   resolve();
-                } catch (error) {
-                  console.log(error);
-                }
               }),
             onRowUpdate: (updatedRow, oldRow) =>
               new Promise((resolve, reject) => {
@@ -126,7 +115,6 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
                   el.id === oldRow.id ? updatedRow : el
                 );
                 setData(updatedRows);
-
                 // Updation takes place by deletion + addition
                 // If property name has been changed, previous key should be removed from nodeObject
                 updatedRow.propertyName !== oldRow.propertyName &&

--- a/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
@@ -74,7 +74,7 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
       />
 
       {/* Properties */}
-      <Box sx={{ width: "90%", ml: 4, maxWidth: "1000px", m: "auto", mb:3}}>
+      <Box sx={{ width: "90%", ml: 4, maxWidth: "1000px", m: "auto", mb: 3 }}>
         <MaterialTable
           data={data}
           columns={[

--- a/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
@@ -3,7 +3,6 @@ import MaterialTable, { MTableToolbar } from "@material-table/core";
 import { useState } from "react";
 
 const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
-  
   const collectProperties = () => {
     let renderedProperties = [];
     Object.keys(nodeObject).forEach((key) => {
@@ -98,15 +97,15 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
               }),
             onRowDelete: (selectedRow) =>
               new Promise((resolve, reject) => {
-                  // Delete property from rendered rows
-                  const updatedRows = [...data];
-                  const index = selectedRow.id;
-                  updatedRows.splice(index, 1);
-                  setData(updatedRows);
+                // Delete property from rendered rows
+                const updatedRows = [...data];
+                const index = selectedRow.id;
+                updatedRows.splice(index, 1);
+                setData(updatedRows);
 
-                  // Delete key-value pair of a property from nodeObject
-                  deletePropertyData(selectedRow.propertyName);
-                  resolve();
+                // Delete key-value pair of a property from nodeObject
+                deletePropertyData(selectedRow.propertyName);
+                resolve();
               }),
             onRowUpdate: (updatedRow, oldRow) =>
               new Promise((resolve, reject) => {

--- a/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListAllEntryProperties.jsx
@@ -74,7 +74,7 @@ const ListAllEntryProperties = ({ nodeObject, setNodeObject }) => {
       />
 
       {/* Properties */}
-      <Box sx={{ width: "90%", ml: 4, maxWidth: "1000px", m: "auto" }}>
+      <Box sx={{ width: "90%", ml: 4, maxWidth: "1000px", m: "auto", mb:3}}>
         <MaterialTable
           data={data}
           columns={[


### PR DESCRIPTION
### What
1. When adding a property and confirming the row, the new property is not instantly visible in the table.
2. After adding a property, confirming the row, and saving changes, the new property is visible in the table
3. When deleting a property and confirming, the row is not instantly removed from the table.
4. After deleting a property, confirming, and saving changes, the deleted property is not visible anymore
5. Editing properties is working correctly if we only edit the value, otherwise it doesn't work well

### Screenshot

https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/e7ef1631-3c62-4e80-b24c-838ee8f9ccb5


### Fixes bug(s)

https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/69f9dcba-9ec2-4f07-bca8-8fa413c280ed

I've changed the style of the table and removed pagination to help users to edit properties :
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/9473ac54-aed6-437d-9ef3-5fdea06f98f0)

