### PR TITLE
fix(frontend): Remove Countries and Languages from editable taxonomies

### DIFF
--- a/taxonomy-editor-frontend/src/constants.js
+++ b/taxonomy-editor-frontend/src/constants.js
@@ -20,14 +20,14 @@ export const API_URL = taxonomyApiUrlFromUi(window.location);
 export const ENTER_KEYCODE = 13;
 export const greyHexCode = "#808080";
 
-// List of all taxonomies in Open Food Facts
+// List of all editable taxonomies in Open Food Facts
+// Countries and Languages taxonomlies are not editable
 // https://wiki.openfoodfacts.org/Global_taxonomies#Overview
 export const TAXONOMY_NAMES = [
   "Additives",
   "Allergens",
   "Amino Acids",
   "Categories",
-  "Countries",
   "Data Quality",
   "Food Groups",
   "Improvements",
@@ -35,7 +35,6 @@ export const TAXONOMY_NAMES = [
   "Ingredients Analysis",
   "Ingredients Processing",
   "Labels",
-  "Languages",
   "Minerals",
   "Misc",
   "Nova Groups",

--- a/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
@@ -56,11 +56,6 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
               status: status,
             };
           }
-        )
-        .filter(
-          (project) =>
-            project.taxonomyName !== "Languages" &&
-            project.taxonomyName !== "Countries"
         );
 
       newProjects = backendProjects;

--- a/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
@@ -36,26 +36,32 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
     let newProjects: ProjectType[] = [];
 
     if (data) {
-      const backendProjects = data.map(
-        ({
-          id,
-          branch_name,
-          taxonomy_name,
-          description,
-          errors_count,
-          status,
-        }) => {
-          return {
-            id, // needed by MaterialTable as key
-            projectName: id,
-            taxonomyName: toTitleCase(taxonomy_name),
-            branchName: branch_name,
-            description: description,
-            errors_count: errors_count,
-            status: status,
-          };
-        }
-      );
+      const backendProjects = data
+        .map(
+          ({
+            id,
+            branch_name,
+            taxonomy_name,
+            description,
+            errors_count,
+            status,
+          }) => {
+            return {
+              id, // needed by MaterialTable as key
+              projectName: id,
+              taxonomyName: toTitleCase(taxonomy_name),
+              branchName: branch_name,
+              description: description,
+              errors_count: errors_count,
+              status: status,
+            };
+          }
+        )
+        .filter(
+          (project) =>
+            project.taxonomyName !== "Languages" &&
+            project.taxonomyName !== "Countries"
+        );
 
       newProjects = backendProjects;
     }

--- a/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
@@ -36,27 +36,26 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
     let newProjects: ProjectType[] = [];
 
     if (data) {
-      const backendProjects = data
-        .map(
-          ({
-            id,
-            branch_name,
-            taxonomy_name,
-            description,
-            errors_count,
-            status,
-          }) => {
-            return {
-              id, // needed by MaterialTable as key
-              projectName: id,
-              taxonomyName: toTitleCase(taxonomy_name),
-              branchName: branch_name,
-              description: description,
-              errors_count: errors_count,
-              status: status,
-            };
-          }
-        );
+      const backendProjects = data.map(
+        ({
+          id,
+          branch_name,
+          taxonomy_name,
+          description,
+          errors_count,
+          status,
+        }) => {
+          return {
+            id, // needed by MaterialTable as key
+            projectName: id,
+            taxonomyName: toTitleCase(taxonomy_name),
+            branchName: branch_name,
+            description: description,
+            errors_count: errors_count,
+            status: status,
+          };
+        }
+      );
 
       newProjects = backendProjects;
     }


### PR DESCRIPTION
### What
Currently, there is an unintended capability to edit languages and countries taxonomies in the editor. This behavior needs correction.

### To Do:
- [x] Disable the ability to import languages and countries taxonomies from GitHub.
- [x] Ensure that languages and countries taxonomies are not displayed in the existing projects table.


### Part of 
[https://github.com/openfoodfacts/taxonomy-editor/issues/376](issue376)
