### PR TITLE
fix(frontend): Handle no error case on errors page

### DIFF
--- a/taxonomy-editor-frontend/src/pages/errors/index.jsx
+++ b/taxonomy-editor-frontend/src/pages/errors/index.jsx
@@ -10,6 +10,7 @@ import {
   TableBody,
   TableHead,
   TableContainer,
+  Stack,
 } from "@mui/material";
 import MaterialTable from "@material-table/core";
 import { Alert, CircularProgress } from "@mui/material";
@@ -91,33 +92,46 @@ const Errors = ({ addNavLinks }) => {
           </TableBody>
         </Table>
       </TableContainer>
-      <Alert severity="warning">
-        These errors must be fixed manually via Github!
-      </Alert>
-      <Box
-        sx={{
-          border: "solid",
-          borderWidth: 1.5,
-        }}
+      <Stack
+        sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
       >
-        <MaterialTable
-          data={errors}
-          columns={[
-            {
-              title: "No.",
-              field: "id",
-              width: "10%",
-            },
-            { title: "Error", field: "error" },
-          ]}
-          title="Errors"
-          options={{
-            tableLayout: "fixed",
-            pageSize: 50,
-            pageSizeOptions: ["20", "50", "100", "200"],
-          }}
-        />
-      </Box>
+        {errors.length > 0 && (
+          <>
+            <Alert severity="warning">
+              These errors must be fixed manually via Github!
+            </Alert>
+            <Box
+              sx={{
+                border: "solid",
+                borderWidth: 1.5,
+              }}
+            >
+              <MaterialTable
+                data={errors}
+                columns={[
+                  {
+                    title: "No.",
+                    field: "id",
+                    width: "10%",
+                  },
+                  { title: "Error", field: "error" },
+                ]}
+                title="Errors"
+                options={{
+                  tableLayout: "fixed",
+                  pageSize: 50,
+                  pageSizeOptions: ["20", "50", "100", "200"],
+                }}
+              />
+            </Box>
+          </>
+        )}
+        {errors.length === 0 && (
+          <Typography>
+            No Error, {toTitleCase(taxonomyName)} can be edited
+          </Typography>
+        )}
+      </Stack>
     </Box>
   );
 };


### PR DESCRIPTION
###Current situation
if the project has no error while parsing and we naviagte to errors page, this is what we see :


![Image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/26af1e12-3f23-44e8-a097-864e5975d214)

###TO-DO
if no errors, the table and warning are not displayed.

![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/c7a9fb87-89d7-48af-9366-40de661fa350)

### Part of 
[https://github.com/openfoodfacts/taxonomy-editor/issues/383](url)
