### PR TITLE
chore: Log more expressive errors for missing child links

### DIFF
--- a/parser/openfoodfacts_taxonomy_parser/parser/parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser/parser.py
@@ -7,16 +7,9 @@ import timeit
 import iso639
 from neo4j import GraphDatabase, Session, Transaction
 
-from .logger import ParserConsoleLogger
 from ..utils import get_project_name, normalize_text
-from .taxonomy_parser import (
-    NodeType,
-    PreviousLink,
-    Taxonomy,
-    TaxonomyParser,
-    NodeData,
-    ChildLink,
-)
+from .logger import ParserConsoleLogger
+from .taxonomy_parser import ChildLink, NodeData, NodeType, PreviousLink, Taxonomy, TaxonomyParser
 
 
 class Parser:
@@ -135,9 +128,7 @@ class Parser:
                 f"Created {count} 'is_before' links, {len(previous_links)} links expected"
             )
 
-    def _create_child_links(
-        self, child_links: list[ChildLink], project_label: str
-    ):
+    def _create_child_links(self, child_links: list[ChildLink], project_label: str):
         """Create the 'is_child_of' relations between nodes"""
         self.parser_logger.info("Creating 'is_child_of' links")
         start_time = timeit.default_timer()
@@ -158,9 +149,7 @@ class Parser:
             """
         )
 
-        normalised_result = self.session.run(
-            query, child_links=child_links
-        )
+        normalised_result = self.session.run(query, child_links=child_links)
         count = normalised_result.value()[0]
 
         self.parser_logger.info(

--- a/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
@@ -361,7 +361,7 @@ class TaxonomyParser:
         for lc, child_link in missing_child_links:
             self.parser_logger.error(
                 f"Missing child link at line {child_link['line_position']}: "
-                f"parent id {child_link['parent_id']} not found in tags_ids_{lc}"
+                f"parent_id {child_link['parent_id']} not found in tags_ids_{lc}"
             )
             missing_child_links_positions.add(child_link["line_position"])
 

--- a/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
@@ -3,13 +3,13 @@ import logging
 import re
 import sys
 import timeit
-from enum import Enum
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Iterator, TypedDict
 
-from .logger import ParserConsoleLogger
-from .exception import DuplicateIDError
 from ..utils import normalize_filename, normalize_text
+from .exception import DuplicateIDError
+from .logger import ParserConsoleLogger
 
 
 class NodeType(str, Enum):


### PR DESCRIPTION
### What

- Taxonomy parser now checks for valid child links and logs out the missing child links in the parsing errors

### Screenshot
<img width="1396" alt="Screenshot 2024-02-01 at 17 45 58" src="https://github.com/openfoodfacts/taxonomy-editor/assets/77902715/9edbdc48-565b-4252-a4cf-ba0fa33b6762">


### Fixes bug(s)
- Partly fixes: https://github.com/openfoodfacts/taxonomy-editor/issues/356
