### PR TITLE
feat: add automatic client SDK generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,6 @@ local_config_lint: ## Run on lint configuration files
 local_generate_sdk: ## Generate client SDK from OpenAPI spec
 	@echo "🍜 Generating client SDK from OpenAPI spec"
 	cd backend && make generate_spec
-	npm run lint
 	cd taxonomy-editor-frontend && npm run generate:api
 
 
@@ -117,8 +116,6 @@ dev: build up ## Build and run the project
 # dev tools #
 #-----------#
 
-
-# Generate client SDK from OpenAPI spec
 generate_sdk: ## Generate client SDK from OpenAPI spec
 	@echo "🍜 Generating client SDK from OpenAPI spec"
 	${DOCKER_COMPOSE} run --rm taxonomy_api python -m openapi.generate_openapi_spec

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,13 @@ local_config_lint: ## Run on lint configuration files
 	npm run lint
 
 
+local_generate_sdk: ## Generate client SDK from OpenAPI spec
+	@echo "🍜 Generating client SDK from OpenAPI spec"
+	cd backend && make generate_spec
+	npm run lint
+	cd taxonomy-editor-frontend && npm run generate:api
+
+
 local_quality: local_backend_quality local_frontend_quality local_config_quality ## Run lint on local code
 
 local_backend_quality: ## Run lint on local backend code
@@ -110,6 +117,13 @@ dev: build up ## Build and run the project
 # dev tools #
 #-----------#
 
+
+# Generate client SDK from OpenAPI spec
+generate_sdk: ## Generate client SDK from OpenAPI spec
+	@echo "🍜 Generating client SDK from OpenAPI spec"
+	${DOCKER_COMPOSE} run --rm taxonomy_api python -m openapi.generate_openapi_spec
+	${DOCKER_COMPOSE} run --rm taxonomy_editor_code npm run lint
+	${DOCKER_COMPOSE} run --rm taxonomy_node npm run generate:api
 
 # lint code
 lint: backend_lint frontend_lint config_lint ## Run all linters

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,6 +50,7 @@ COPY parser /parser
 USER off:off
 COPY --chown=off:off ./backend/editor /code/editor
 COPY --chown=off:off ./backend/sample /code/sample
+COPY --chown=off:off ./backend/openapi /code/openapi
 RUN find /code/sample -type f -name '*.py' -exec chmod +x {} \;
 
 CMD ["uvicorn", "editor.api:app", "--host", "0.0.0.0", "--port", "80"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,5 +1,5 @@
 generate_spec: ## Generate swagger spec
-	poetry run python -m openapi.generate_openapi_spec
+	poetry run python -m openapi.generate_openapi_spec && cd .. && npm run lint
 
 
 #------------#

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,15 @@
+generate_spec: ## Generate swagger spec
+	poetry run python -m openapi.generate_openapi_spec
+
+
+#------------#
+# utils #
+#------------#
+
+.DEFAULT_GOAL := help
+
+.PHONY: generate_spec help
+
+# this command will grep targets and the following ## comment will be used as description
+help: ## Description of the available commands
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -107,9 +107,9 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     for pydantic_error in exc.errors():
         # Add custom message for status filter
         if pydantic_error["loc"] == ("query", "status"):
-            pydantic_error[
-                "msg"
-            ] = "Status filter must be one of: OPEN, CLOSED or should be omitted"
+            pydantic_error["msg"] = (
+                "Status filter must be one of: OPEN, CLOSED or should be omitted"
+            )
         reformatted_errors.append(pydantic_error)
     return JSONResponse(
         status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -107,9 +107,9 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     for pydantic_error in exc.errors():
         # Add custom message for status filter
         if pydantic_error["loc"] == ("query", "status"):
-            pydantic_error["msg"] = (
-                "Status filter must be one of: OPEN, CLOSED or should be omitted"
-            )
+            pydantic_error[
+                "msg"
+            ] = "Status filter must be one of: OPEN, CLOSED or should be omitted"
         reformatted_errors.append(pydantic_error)
     return JSONResponse(
         status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/editor/models/project_models.py
+++ b/backend/editor/models/project_models.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from enum import Enum
+from typing import Any
 
 from neo4j.time import DateTime
-from pydantic import field_serializer
+from pydantic import field_validator
 
 from .base_models import BaseModel
 
@@ -26,14 +28,17 @@ class ProjectCreate(BaseModel):
 
 
 class Project(ProjectCreate):
-    created_at: DateTime
+    created_at: datetime
     github_checkout_commit_sha: str | None = None
     github_file_latest_sha: str | None = None
     github_pr_url: str | None = None
 
-    @field_serializer("created_at")
-    def serialize_created_at(self, created_at: DateTime):
-        return created_at.iso_format()
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def convert_to_native_datetime(cls, v: Any) -> datetime:
+        if not isinstance(v, DateTime):
+            raise ValueError("Unexpected type for created_at, expected neo4j.time.DateTime")
+        return v.to_native()
 
 
 class ProjectEdit(BaseModel):

--- a/backend/editor/models/project_models.py
+++ b/backend/editor/models/project_models.py
@@ -1,8 +1,7 @@
 from enum import Enum
 
-from .types.datetime import DateTime
-
 from .base_models import BaseModel
+from .types.datetime import DateTime
 
 
 # Project status states

--- a/backend/editor/models/project_models.py
+++ b/backend/editor/models/project_models.py
@@ -1,9 +1,6 @@
-from datetime import datetime
 from enum import Enum
-from typing import Any
 
-from neo4j.time import DateTime
-from pydantic import field_validator
+from .types.datetime import DateTime
 
 from .base_models import BaseModel
 
@@ -28,17 +25,10 @@ class ProjectCreate(BaseModel):
 
 
 class Project(ProjectCreate):
-    created_at: datetime
+    created_at: DateTime
     github_checkout_commit_sha: str | None = None
     github_file_latest_sha: str | None = None
     github_pr_url: str | None = None
-
-    @field_validator("created_at", mode="before")
-    @classmethod
-    def convert_to_native_datetime(cls, v: Any) -> datetime:
-        if not isinstance(v, DateTime):
-            raise ValueError("Unexpected type for created_at, expected neo4j.time.DateTime")
-        return v.to_native()
 
 
 class ProjectEdit(BaseModel):

--- a/backend/editor/models/types/datetime.py
+++ b/backend/editor/models/types/datetime.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Annotated, Any
+
 from neo4j.time import DateTime as Neo4JDateTime
 from pydantic import BeforeValidator
 

--- a/backend/editor/models/types/datetime.py
+++ b/backend/editor/models/types/datetime.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from typing import Annotated, Any
+from neo4j.time import DateTime as Neo4JDateTime
+from pydantic import BeforeValidator
+
+
+def convert_to_native_datetime(raw_value: Any) -> datetime:
+    if not isinstance(raw_value, Neo4JDateTime):
+        # Pass through non-datetime values to the default validator
+        return raw_value
+    return raw_value.to_native()
+
+
+# Augmented type for datetime fields that are stored as Neo4JDateTime in the database
+DateTime = Annotated[datetime, BeforeValidator(convert_to_native_datetime)]

--- a/backend/openapi/generate_openapi_spec.py
+++ b/backend/openapi/generate_openapi_spec.py
@@ -1,0 +1,25 @@
+import json
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+from editor.api import app as editor_app
+
+
+# From https://fastapi.tiangolo.com/advanced/generate-clients/
+def generate_openapi_spec(app: FastAPI):
+    with open("openapi/openapi.json", "w") as f:
+        json.dump(
+            get_openapi(
+                title=app.title,
+                version=app.version,
+                openapi_version=app.openapi_version,
+                description=app.description,
+                routes=app.routes,
+            ),
+            f,
+        )
+
+
+if __name__ == "__main__":
+    generate_openapi_spec(editor_app)

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -65,6 +65,45 @@
         }
       }
     },
+    "/{taxonomy_name}/{branch}/project": {
+      "get": {
+        "summary": "Get Project Info",
+        "description": "Get information about a Taxonomy Editor project",
+        "operationId": "get_project_info__taxonomy_name___branch__project_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Project" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/{taxonomy_name}/{branch}/set-project-status": {
       "get": {
         "summary": "Set Project Status",
@@ -1089,11 +1128,11 @@
         }
       }
     },
-    "/{taxonomy_name}/{branch}/delete": {
+    "/{taxonomy_name}/{branch}": {
       "delete": {
         "summary": "Delete Project",
         "description": "Delete a project",
-        "operationId": "delete_project__taxonomy_name___branch__delete_delete",
+        "operationId": "delete_project__taxonomy_name___branch__delete",
         "parameters": [
           {
             "name": "branch",
@@ -1109,10 +1148,7 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
-          },
+          "204": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1170,6 +1206,46 @@
         "type": "object",
         "required": ["preceding_lines"],
         "title": "Header"
+      },
+      "Project": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/ProjectStatus" }],
+            "default": "LOADING"
+          },
+          "taxonomy_name": { "type": "string", "title": "Taxonomy Name" },
+          "branch_name": { "type": "string", "title": "Branch Name" },
+          "description": { "type": "string", "title": "Description" },
+          "is_from_github": { "type": "boolean", "title": "Is From Github" },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "github_checkout_commit_sha": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Github Checkout Commit Sha"
+          },
+          "github_file_latest_sha": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Github File Latest Sha"
+          },
+          "github_pr_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Github Pr Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "taxonomy_name",
+          "branch_name",
+          "description",
+          "is_from_github",
+          "created_at"
+        ],
+        "title": "Project"
       },
       "ProjectStatus": {
         "type": "string",

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -185,39 +185,6 @@
           }
         }
       },
-      "post": {
-        "summary": "Create Node",
-        "description": "Creating a new node in a taxonomy",
-        "operationId": "create_node__taxonomy_name___branch__nodes_post",
-        "parameters": [
-          {
-            "name": "branch",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string", "title": "Branch" }
-          },
-          {
-            "name": "taxonomy_name",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string", "title": "Taxonomy Name" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
-              }
-            }
-          }
-        }
-      },
       "delete": {
         "summary": "Delete Node",
         "description": "Deleting given node from a taxonomy",
@@ -509,6 +476,47 @@
         ],
         "responses": {
           "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Entry Node",
+        "description": "Creating a new entry node in a taxonomy",
+        "operationId": "create_entry_node__taxonomy_name___branch__entry_post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/EntryNodeCreate" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
             "description": "Successful Response",
             "content": { "application/json": { "schema": {} } }
           },
@@ -1172,18 +1180,19 @@
         "required": ["file", "description"],
         "title": "Body_upload_taxonomy__taxonomy_name___branch__upload_post"
       },
-      "Footer": {
+      "EntryNodeCreate": {
         "properties": {
-          "preceding_lines": {
-            "items": {},
-            "type": "array",
-            "title": "Preceding Lines"
+          "name": { "type": "string", "title": "Name" },
+          "main_language_code": {
+            "type": "string",
+            "title": "Main Language Code"
           }
         },
         "type": "object",
-        "required": ["preceding_lines"],
-        "title": "Footer"
+        "required": ["name", "main_language_code"],
+        "title": "EntryNodeCreate"
       },
+      "Footer": { "properties": {}, "type": "object", "title": "Footer" },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -1195,18 +1204,7 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "Header": {
-        "properties": {
-          "preceding_lines": {
-            "items": {},
-            "type": "array",
-            "title": "Preceding Lines"
-          }
-        },
-        "type": "object",
-        "required": ["preceding_lines"],
-        "title": "Header"
-      },
+      "Header": { "properties": {}, "type": "object", "title": "Header" },
       "Project": {
         "properties": {
           "id": { "type": "string", "title": "Id" },

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -1,0 +1,1195 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Open Food Facts Taxonomy Editor API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Hello",
+        "operationId": "hello__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
+    },
+    "/ping": {
+      "get": {
+        "summary": "Pong",
+        "description": "Check server health",
+        "operationId": "pong_ping_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
+    },
+    "/projects": {
+      "get": {
+        "summary": "List All Projects",
+        "description": "List projects created in the Taxonomy Editor with a status filter",
+        "operationId": "list_all_projects_projects_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/ProjectStatus" },
+                { "type": "null" }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/set-project-status": {
+      "get": {
+        "summary": "Set Project Status",
+        "description": "Set the status of a Taxonomy Editor project",
+        "operationId": "set_project_status__taxonomy_name___branch__set_project_status_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/ProjectStatus" },
+                { "type": "null" }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/nodes": {
+      "get": {
+        "summary": "Find All Nodes",
+        "description": "Get all nodes within taxonomy",
+        "operationId": "find_all_nodes__taxonomy_name___branch__nodes_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Node",
+        "description": "Creating a new node in a taxonomy",
+        "operationId": "create_node__taxonomy_name___branch__nodes_post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Node",
+        "description": "Deleting given node from a taxonomy",
+        "operationId": "delete_node__taxonomy_name___branch__nodes_delete",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/rootentries": {
+      "get": {
+        "summary": "Find All Root Nodes",
+        "description": "Get all root nodes within taxonomy",
+        "operationId": "find_all_root_nodes__taxonomy_name___branch__rootentries_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/entry/{entry}": {
+      "get": {
+        "summary": "Find One Entry",
+        "description": "Get entry corresponding to id within taxonomy",
+        "operationId": "find_one_entry__taxonomy_name___branch__entry__entry__get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "entry",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Entry" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Edit Entry",
+        "description": "Editing an entry in a taxonomy.\nNew key-value pairs can be added, old key-value pairs can be updated.\nURL will be of format '/entry/<id>'",
+        "operationId": "edit_entry__taxonomy_name___branch__entry__entry__post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "entry",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Entry" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/entry/{entry}/parents": {
+      "get": {
+        "summary": "Find One Entry Parents",
+        "description": "Get parents for a entry corresponding to id within taxonomy",
+        "operationId": "find_one_entry_parents__taxonomy_name___branch__entry__entry__parents_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "entry",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Entry" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/entry/{entry}/children": {
+      "get": {
+        "summary": "Find One Entry Children",
+        "description": "Get children for a entry corresponding to id within taxonomy",
+        "operationId": "find_one_entry_children__taxonomy_name___branch__entry__entry__children_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "entry",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Entry" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Edit Entry Children",
+        "description": "Editing an entry's children in a taxonomy.\nNew children can be added, old children can be removed.\nURL will be of format '/entry/<id>/children'",
+        "operationId": "edit_entry_children__taxonomy_name___branch__entry__entry__children_post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "entry",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Entry" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/entry": {
+      "get": {
+        "summary": "Find All Entries",
+        "description": "Get all entries within taxonomy",
+        "operationId": "find_all_entries__taxonomy_name___branch__entry_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/synonym/{synonym}": {
+      "get": {
+        "summary": "Find One Synonym",
+        "description": "Get synonym corresponding to id within taxonomy",
+        "operationId": "find_one_synonym__taxonomy_name___branch__synonym__synonym__get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "synonym",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Synonym" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Edit Synonyms",
+        "description": "Editing a synonym in a taxonomy.\nNew key-value pairs can be added, old key-value pairs can be updated.\nURL will be of format '/synonym/<id>'",
+        "operationId": "edit_synonyms__taxonomy_name___branch__synonym__synonym__post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "synonym",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Synonym" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/synonym": {
+      "get": {
+        "summary": "Find All Synonyms",
+        "description": "Get all synonyms within taxonomy",
+        "operationId": "find_all_synonyms__taxonomy_name___branch__synonym_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/stopword/{stopword}": {
+      "get": {
+        "summary": "Find One Stopword",
+        "description": "Get stopword corresponding to id within taxonomy",
+        "operationId": "find_one_stopword__taxonomy_name___branch__stopword__stopword__get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "stopword",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Stopword" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Edit Stopwords",
+        "description": "Editing a stopword in a taxonomy.\nNew key-value pairs can be added, old key-value pairs can be updated.\nURL will be of format '/stopword/<id>'",
+        "operationId": "edit_stopwords__taxonomy_name___branch__stopword__stopword__post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "stopword",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Stopword" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/stopword": {
+      "get": {
+        "summary": "Find All Stopwords",
+        "description": "Get all stopwords within taxonomy",
+        "operationId": "find_all_stopwords__taxonomy_name___branch__stopword_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/header": {
+      "get": {
+        "summary": "Find Header",
+        "description": "Get __header__ within taxonomy",
+        "operationId": "find_header__taxonomy_name___branch__header_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Edit Header",
+        "description": "Editing the __header__ in a taxonomy.",
+        "operationId": "edit_header__taxonomy_name___branch__header_post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Header" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/footer": {
+      "get": {
+        "summary": "Find Footer",
+        "description": "Get __footer__ within taxonomy",
+        "operationId": "find_footer__taxonomy_name___branch__footer_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Edit Footer",
+        "description": "Editing the __footer__ in a taxonomy.",
+        "operationId": "edit_footer__taxonomy_name___branch__footer_post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Footer" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/parsing_errors": {
+      "get": {
+        "summary": "Find All Errors",
+        "description": "Get all errors within taxonomy",
+        "operationId": "find_all_errors__taxonomy_name___branch__parsing_errors_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/search": {
+      "get": {
+        "summary": "Search Node",
+        "operationId": "search_node__taxonomy_name___branch__search_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "title": "Query" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/downloadexport": {
+      "get": {
+        "summary": "Export To Text File",
+        "operationId": "export_to_text_file__taxonomy_name___branch__downloadexport_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/githubexport": {
+      "get": {
+        "summary": "Export To Github",
+        "operationId": "export_to_github__taxonomy_name___branch__githubexport_get",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/import": {
+      "post": {
+        "summary": "Import From Github",
+        "description": "Get taxonomy from Product Opener GitHub repository",
+        "operationId": "import_from_github__taxonomy_name___branch__import_post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/upload": {
+      "post": {
+        "summary": "Upload Taxonomy",
+        "description": "Upload taxonomy file to be parsed",
+        "operationId": "upload_taxonomy__taxonomy_name___branch__upload_post",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_taxonomy__taxonomy_name___branch__upload_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{taxonomy_name}/{branch}/delete": {
+      "delete": {
+        "summary": "Delete Project",
+        "description": "Delete a project",
+        "operationId": "delete_project__taxonomy_name___branch__delete_delete",
+        "parameters": [
+          {
+            "name": "branch",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Branch" }
+          },
+          {
+            "name": "taxonomy_name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Taxonomy Name" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Body_upload_taxonomy__taxonomy_name___branch__upload_post": {
+        "properties": {
+          "file": { "type": "string", "format": "binary", "title": "File" },
+          "description": { "type": "string", "title": "Description" }
+        },
+        "type": "object",
+        "required": ["file", "description"],
+        "title": "Body_upload_taxonomy__taxonomy_name___branch__upload_post"
+      },
+      "Footer": {
+        "properties": {
+          "preceding_lines": {
+            "items": {},
+            "type": "array",
+            "title": "Preceding Lines"
+          }
+        },
+        "type": "object",
+        "required": ["preceding_lines"],
+        "title": "Footer"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": { "$ref": "#/components/schemas/ValidationError" },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Header": {
+        "properties": {
+          "preceding_lines": {
+            "items": {},
+            "type": "array",
+            "title": "Preceding Lines"
+          }
+        },
+        "type": "object",
+        "required": ["preceding_lines"],
+        "title": "Header"
+      },
+      "ProjectStatus": {
+        "type": "string",
+        "enum": ["OPEN", "EXPORTED", "LOADING", "FAILED"],
+        "title": "ProjectStatus"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": { "type": "string", "title": "Message" },
+          "type": { "type": "string", "title": "Error Type" }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -18,6 +18,7 @@ services:
       - ./backend/editor:/code/editor
       - ./backend/sample:/code/sample
       - ./backend/tests:/code/tests
+      - ./backend/openapi:/code/openapi
       - ./parser:/parser
       # for linting / checks purpose
       - ./backend/pyproject.toml:/code/pyproject.toml
@@ -65,6 +66,7 @@ services:
       - ./taxonomy-editor-frontend/.eslintrc.json:/opt/taxonomy-editor/.eslintrc.json
       - ./taxonomy-editor-frontend/craco.config.js:/opt/taxonomy-editor/craco.config.js
       - ./taxonomy-editor-frontend/tsconfig.js:/opt/taxonomy-editor/tsconfig.js
+      - ./backend/openapi/openapi.json:/opt/backend/openapi/openapi.json
   taxonomy_frontend:
     image: taxonomy-editor/taxonomy_frontend:dev
     # instruction to build locally

--- a/taxonomy-editor-frontend/package-lock.json
+++ b/taxonomy-editor-frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query": "^5.17.9",
         "@yaireo/dragsort": "^1.3.1",
         "@yaireo/tagify": "^4.17.9",
+        "axios": "^1.6.7",
         "fast-deep-equal": "^3.1.3",
         "iso-639-1": "^2.1.15",
         "react": "^18.2.0",
@@ -43,6 +44,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^8.0.3",
         "lint-staged": "^15.2.0",
+        "openapi-typescript-codegen": "^0.27.0",
         "prettier": "2.8.2"
       }
     },
@@ -62,6 +64,43 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-10.1.0.tgz",
+      "integrity": "sha512-3e+viyMuXdrcK8v5pvP+SDoAQ77FH6OyRmuK48SZKmdHJRFm87RsSs8qm6kP39a/pOPURByJw+OXzQIqcfmKtA==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.11",
+        "@types/lodash.clonedeep": "^4.5.7",
+        "js-yaml": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2949,6 +2988,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -4275,6 +4320,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -5286,6 +5346,29 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -9298,6 +9381,36 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/harmony-reflect": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
@@ -12274,6 +12387,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -13082,6 +13201,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-typescript-codegen": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.27.0.tgz",
+      "integrity": "sha512-QyQEod/vuel3zfnTRC3GgmYsqLPSBzB2OL4ojMYjO9hJmfYW02T+7tbQWEnuqWdhh2KSOBf3L8h59vLStr6vwA==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^10.1.0",
+        "camelcase": "^6.3.0",
+        "commander": "^11.1.0",
+        "fs-extra": "^11.2.0",
+        "handlebars": "^4.7.8"
+      },
+      "bin": {
+        "openapi": "bin/index.js"
+      }
+    },
+    "node_modules/openapi-typescript-codegen/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/openapi-typescript-codegen/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/optionator": {
@@ -14712,6 +14870,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -18050,9 +18213,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -18194,6 +18357,19 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -18967,6 +19143,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
+    },
     "node_modules/workbox-background-sync": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.5.4.tgz",
@@ -19444,6 +19626,36 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-10.1.0.tgz",
+      "integrity": "sha512-3e+viyMuXdrcK8v5pvP+SDoAQ77FH6OyRmuK48SZKmdHJRFm87RsSs8qm6kP39a/pOPURByJw+OXzQIqcfmKtA==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.11",
+        "@types/lodash.clonedeep": "^4.5.7",
+        "js-yaml": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -21408,6 +21620,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -22264,6 +22482,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -23020,6 +23253,28 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
+    },
+    "axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "requires": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -25951,6 +26206,27 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
+    "handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "harmony-reflect": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
@@ -28094,6 +28370,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -28668,6 +28950,38 @@
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
+      }
+    },
+    "openapi-typescript-codegen": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.27.0.tgz",
+      "integrity": "sha512-QyQEod/vuel3zfnTRC3GgmYsqLPSBzB2OL4ojMYjO9hJmfYW02T+7tbQWEnuqWdhh2KSOBf3L8h59vLStr6vwA==",
+      "dev": true,
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^10.1.0",
+        "camelcase": "^6.3.0",
+        "commander": "^11.1.0",
+        "fs-extra": "^11.2.0",
+        "handlebars": "^4.7.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "optionator": {
@@ -29659,6 +29973,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",
@@ -32120,9 +32439,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -32221,6 +32540,13 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+    },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -32779,6 +33105,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
       "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "workbox-background-sync": {
       "version": "6.5.4",

--- a/taxonomy-editor-frontend/package.json
+++ b/taxonomy-editor-frontend/package.json
@@ -29,7 +29,7 @@
     "prepare": "cd .. && husky install taxonomy-editor-frontend/.husky",
     "lint": "prettier --write .",
     "lint:check": "prettier --check .",
-    "generate:api": "openapi --input ../backend/openapi/openapi.json --output ./src/client --client axios"
+    "generate:api": "openapi --input ../backend/openapi/openapi.json --output ./src/client --client axios && prettier --write ./src/client"
   },
   "proxy": "http://localhost:80",
   "browserslist": {

--- a/taxonomy-editor-frontend/package.json
+++ b/taxonomy-editor-frontend/package.json
@@ -11,6 +11,7 @@
     "@tanstack/react-query": "^5.17.9",
     "@yaireo/dragsort": "^1.3.1",
     "@yaireo/tagify": "^4.17.9",
+    "axios": "^1.6.7",
     "fast-deep-equal": "^3.1.3",
     "iso-639-1": "^2.1.15",
     "react": "^18.2.0",
@@ -27,7 +28,8 @@
     "test": "craco test",
     "prepare": "cd .. && husky install taxonomy-editor-frontend/.husky",
     "lint": "prettier --write .",
-    "lint:check": "prettier --check ."
+    "lint:check": "prettier --check .",
+    "generate:api": "openapi --input ../backend/openapi/openapi.json --output ./src/client --client axios"
   },
   "proxy": "http://localhost:80",
   "browserslist": {
@@ -59,6 +61,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
     "lint-staged": "^15.2.0",
+    "openapi-typescript-codegen": "^0.27.0",
     "prettier": "2.8.2"
   },
   "lint-staged": {

--- a/taxonomy-editor-frontend/src/client/core/ApiError.ts
+++ b/taxonomy-editor-frontend/src/client/core/ApiError.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+    public readonly request: ApiRequestOptions;
+
+    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+        this.request = request;
+    }
+}

--- a/taxonomy-editor-frontend/src/client/core/ApiError.ts
+++ b/taxonomy-editor-frontend/src/client/core/ApiError.ts
@@ -2,24 +2,28 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ApiRequestOptions } from './ApiRequestOptions';
-import type { ApiResult } from './ApiResult';
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+import type { ApiResult } from "./ApiResult";
 
 export class ApiError extends Error {
-    public readonly url: string;
-    public readonly status: number;
-    public readonly statusText: string;
-    public readonly body: any;
-    public readonly request: ApiRequestOptions;
+  public readonly url: string;
+  public readonly status: number;
+  public readonly statusText: string;
+  public readonly body: any;
+  public readonly request: ApiRequestOptions;
 
-    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
-        super(message);
+  constructor(
+    request: ApiRequestOptions,
+    response: ApiResult,
+    message: string
+  ) {
+    super(message);
 
-        this.name = 'ApiError';
-        this.url = response.url;
-        this.status = response.status;
-        this.statusText = response.statusText;
-        this.body = response.body;
-        this.request = request;
-    }
+    this.name = "ApiError";
+    this.url = response.url;
+    this.status = response.status;
+    this.statusText = response.statusText;
+    this.body = response.body;
+    this.request = request;
+  }
 }

--- a/taxonomy-editor-frontend/src/client/core/ApiRequestOptions.ts
+++ b/taxonomy-editor-frontend/src/client/core/ApiRequestOptions.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly url: string;
+    readonly path?: Record<string, any>;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+};

--- a/taxonomy-editor-frontend/src/client/core/ApiRequestOptions.ts
+++ b/taxonomy-editor-frontend/src/client/core/ApiRequestOptions.ts
@@ -3,15 +3,22 @@
 /* tslint:disable */
 /* eslint-disable */
 export type ApiRequestOptions = {
-    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
-    readonly url: string;
-    readonly path?: Record<string, any>;
-    readonly cookies?: Record<string, any>;
-    readonly headers?: Record<string, any>;
-    readonly query?: Record<string, any>;
-    readonly formData?: Record<string, any>;
-    readonly body?: any;
-    readonly mediaType?: string;
-    readonly responseHeader?: string;
-    readonly errors?: Record<number, string>;
+  readonly method:
+    | "GET"
+    | "PUT"
+    | "POST"
+    | "DELETE"
+    | "OPTIONS"
+    | "HEAD"
+    | "PATCH";
+  readonly url: string;
+  readonly path?: Record<string, any>;
+  readonly cookies?: Record<string, any>;
+  readonly headers?: Record<string, any>;
+  readonly query?: Record<string, any>;
+  readonly formData?: Record<string, any>;
+  readonly body?: any;
+  readonly mediaType?: string;
+  readonly responseHeader?: string;
+  readonly errors?: Record<number, string>;
 };

--- a/taxonomy-editor-frontend/src/client/core/ApiResult.ts
+++ b/taxonomy-editor-frontend/src/client/core/ApiResult.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+};

--- a/taxonomy-editor-frontend/src/client/core/ApiResult.ts
+++ b/taxonomy-editor-frontend/src/client/core/ApiResult.ts
@@ -3,9 +3,9 @@
 /* tslint:disable */
 /* eslint-disable */
 export type ApiResult = {
-    readonly url: string;
-    readonly ok: boolean;
-    readonly status: number;
-    readonly statusText: string;
-    readonly body: any;
+  readonly url: string;
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly body: any;
 };

--- a/taxonomy-editor-frontend/src/client/core/CancelablePromise.ts
+++ b/taxonomy-editor-frontend/src/client/core/CancelablePromise.ts
@@ -1,0 +1,131 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isResolved: boolean;
+    readonly isRejected: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    #isResolved: boolean;
+    #isRejected: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isResolved = false;
+        this.#isRejected = false;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isResolved = true;
+                if (this.#resolve) this.#resolve(value);
+            };
+
+            const onReject = (reason?: any): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isRejected = true;
+                if (this.#reject) this.#reject(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#cancelHandlers.push(cancelHandler);
+            };
+
+            Object.defineProperty(onCancel, 'isResolved', {
+                get: (): boolean => this.#isResolved,
+            });
+
+            Object.defineProperty(onCancel, 'isRejected', {
+                get: (): boolean => this.#isRejected,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+     get [Symbol.toStringTag]() {
+            return "Cancellable Promise";
+     }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                console.warn('Cancellation threw an error', error);
+                return;
+            }
+        }
+        this.#cancelHandlers.length = 0;
+        if (this.#reject) this.#reject(new CancelError('Request aborted'));
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}

--- a/taxonomy-editor-frontend/src/client/core/CancelablePromise.ts
+++ b/taxonomy-editor-frontend/src/client/core/CancelablePromise.ts
@@ -3,129 +3,128 @@
 /* tslint:disable */
 /* eslint-disable */
 export class CancelError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CancelError";
+  }
 
-    constructor(message: string) {
-        super(message);
-        this.name = 'CancelError';
-    }
-
-    public get isCancelled(): boolean {
-        return true;
-    }
+  public get isCancelled(): boolean {
+    return true;
+  }
 }
 
 export interface OnCancel {
-    readonly isResolved: boolean;
-    readonly isRejected: boolean;
-    readonly isCancelled: boolean;
+  readonly isResolved: boolean;
+  readonly isRejected: boolean;
+  readonly isCancelled: boolean;
 
-    (cancelHandler: () => void): void;
+  (cancelHandler: () => void): void;
 }
 
 export class CancelablePromise<T> implements Promise<T> {
-    #isResolved: boolean;
-    #isRejected: boolean;
-    #isCancelled: boolean;
-    readonly #cancelHandlers: (() => void)[];
-    readonly #promise: Promise<T>;
-    #resolve?: (value: T | PromiseLike<T>) => void;
-    #reject?: (reason?: any) => void;
+  #isResolved: boolean;
+  #isRejected: boolean;
+  #isCancelled: boolean;
+  readonly #cancelHandlers: (() => void)[];
+  readonly #promise: Promise<T>;
+  #resolve?: (value: T | PromiseLike<T>) => void;
+  #reject?: (reason?: any) => void;
 
-    constructor(
-        executor: (
-            resolve: (value: T | PromiseLike<T>) => void,
-            reject: (reason?: any) => void,
-            onCancel: OnCancel
-        ) => void
-    ) {
-        this.#isResolved = false;
-        this.#isRejected = false;
-        this.#isCancelled = false;
-        this.#cancelHandlers = [];
-        this.#promise = new Promise<T>((resolve, reject) => {
-            this.#resolve = resolve;
-            this.#reject = reject;
+  constructor(
+    executor: (
+      resolve: (value: T | PromiseLike<T>) => void,
+      reject: (reason?: any) => void,
+      onCancel: OnCancel
+    ) => void
+  ) {
+    this.#isResolved = false;
+    this.#isRejected = false;
+    this.#isCancelled = false;
+    this.#cancelHandlers = [];
+    this.#promise = new Promise<T>((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
 
-            const onResolve = (value: T | PromiseLike<T>): void => {
-                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-                    return;
-                }
-                this.#isResolved = true;
-                if (this.#resolve) this.#resolve(value);
-            };
-
-            const onReject = (reason?: any): void => {
-                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-                    return;
-                }
-                this.#isRejected = true;
-                if (this.#reject) this.#reject(reason);
-            };
-
-            const onCancel = (cancelHandler: () => void): void => {
-                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-                    return;
-                }
-                this.#cancelHandlers.push(cancelHandler);
-            };
-
-            Object.defineProperty(onCancel, 'isResolved', {
-                get: (): boolean => this.#isResolved,
-            });
-
-            Object.defineProperty(onCancel, 'isRejected', {
-                get: (): boolean => this.#isRejected,
-            });
-
-            Object.defineProperty(onCancel, 'isCancelled', {
-                get: (): boolean => this.#isCancelled,
-            });
-
-            return executor(onResolve, onReject, onCancel as OnCancel);
-        });
-    }
-
-     get [Symbol.toStringTag]() {
-            return "Cancellable Promise";
-     }
-
-    public then<TResult1 = T, TResult2 = never>(
-        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
-        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
-    ): Promise<TResult1 | TResult2> {
-        return this.#promise.then(onFulfilled, onRejected);
-    }
-
-    public catch<TResult = never>(
-        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
-    ): Promise<T | TResult> {
-        return this.#promise.catch(onRejected);
-    }
-
-    public finally(onFinally?: (() => void) | null): Promise<T> {
-        return this.#promise.finally(onFinally);
-    }
-
-    public cancel(): void {
+      const onResolve = (value: T | PromiseLike<T>): void => {
         if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-            return;
+          return;
         }
-        this.#isCancelled = true;
-        if (this.#cancelHandlers.length) {
-            try {
-                for (const cancelHandler of this.#cancelHandlers) {
-                    cancelHandler();
-                }
-            } catch (error) {
-                console.warn('Cancellation threw an error', error);
-                return;
-            }
-        }
-        this.#cancelHandlers.length = 0;
-        if (this.#reject) this.#reject(new CancelError('Request aborted'));
-    }
+        this.#isResolved = true;
+        if (this.#resolve) this.#resolve(value);
+      };
 
-    public get isCancelled(): boolean {
-        return this.#isCancelled;
+      const onReject = (reason?: any): void => {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+          return;
+        }
+        this.#isRejected = true;
+        if (this.#reject) this.#reject(reason);
+      };
+
+      const onCancel = (cancelHandler: () => void): void => {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+          return;
+        }
+        this.#cancelHandlers.push(cancelHandler);
+      };
+
+      Object.defineProperty(onCancel, "isResolved", {
+        get: (): boolean => this.#isResolved,
+      });
+
+      Object.defineProperty(onCancel, "isRejected", {
+        get: (): boolean => this.#isRejected,
+      });
+
+      Object.defineProperty(onCancel, "isCancelled", {
+        get: (): boolean => this.#isCancelled,
+      });
+
+      return executor(onResolve, onReject, onCancel as OnCancel);
+    });
+  }
+
+  get [Symbol.toStringTag]() {
+    return "Cancellable Promise";
+  }
+
+  public then<TResult1 = T, TResult2 = never>(
+    onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return this.#promise.then(onFulfilled, onRejected);
+  }
+
+  public catch<TResult = never>(
+    onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+  ): Promise<T | TResult> {
+    return this.#promise.catch(onRejected);
+  }
+
+  public finally(onFinally?: (() => void) | null): Promise<T> {
+    return this.#promise.finally(onFinally);
+  }
+
+  public cancel(): void {
+    if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+      return;
     }
+    this.#isCancelled = true;
+    if (this.#cancelHandlers.length) {
+      try {
+        for (const cancelHandler of this.#cancelHandlers) {
+          cancelHandler();
+        }
+      } catch (error) {
+        console.warn("Cancellation threw an error", error);
+        return;
+      }
+    }
+    this.#cancelHandlers.length = 0;
+    if (this.#reject) this.#reject(new CancelError("Request aborted"));
+  }
+
+  public get isCancelled(): boolean {
+    return this.#isCancelled;
+  }
 }

--- a/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
+++ b/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    CREDENTIALS: 'include' | 'omit' | 'same-origin';
+    TOKEN?: string | Resolver<string> | undefined;
+    USERNAME?: string | Resolver<string> | undefined;
+    PASSWORD?: string | Resolver<string> | undefined;
+    HEADERS?: Headers | Resolver<Headers> | undefined;
+    ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+    BASE: '',
+    VERSION: '0.1.0',
+    WITH_CREDENTIALS: false,
+    CREDENTIALS: 'include',
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};

--- a/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
+++ b/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ApiRequestOptions } from './ApiRequestOptions';
+import { API_URL } from '../../constants';
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 type Headers = Record<string, string>;
@@ -20,7 +21,8 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: '',
+    // TODO: Used to keep API_URL backward compatible with existing code, update API_URL when possible
+    BASE: API_URL.substring(0, API_URL.length - 2),
     VERSION: '0.1.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',

--- a/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
+++ b/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
@@ -2,33 +2,33 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ApiRequestOptions } from './ApiRequestOptions';
-import { API_URL } from '../../constants';
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+import { API_URL } from "../../constants";
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 type Headers = Record<string, string>;
 
 export type OpenAPIConfig = {
-    BASE: string;
-    VERSION: string;
-    WITH_CREDENTIALS: boolean;
-    CREDENTIALS: 'include' | 'omit' | 'same-origin';
-    TOKEN?: string | Resolver<string> | undefined;
-    USERNAME?: string | Resolver<string> | undefined;
-    PASSWORD?: string | Resolver<string> | undefined;
-    HEADERS?: Headers | Resolver<Headers> | undefined;
-    ENCODE_PATH?: ((path: string) => string) | undefined;
+  BASE: string;
+  VERSION: string;
+  WITH_CREDENTIALS: boolean;
+  CREDENTIALS: "include" | "omit" | "same-origin";
+  TOKEN?: string | Resolver<string> | undefined;
+  USERNAME?: string | Resolver<string> | undefined;
+  PASSWORD?: string | Resolver<string> | undefined;
+  HEADERS?: Headers | Resolver<Headers> | undefined;
+  ENCODE_PATH?: ((path: string) => string) | undefined;
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    // TODO: Used to keep API_URL backward compatible with existing code, update API_URL when possible
-    BASE: API_URL.substring(0, API_URL.length - 1),
-    VERSION: '0.1.0',
-    WITH_CREDENTIALS: false,
-    CREDENTIALS: 'include',
-    TOKEN: undefined,
-    USERNAME: undefined,
-    PASSWORD: undefined,
-    HEADERS: undefined,
-    ENCODE_PATH: undefined,
+  // TODO: Used to keep API_URL backward compatible with existing code, update API_URL when possible
+  BASE: API_URL.substring(0, API_URL.length - 1),
+  VERSION: "0.1.0",
+  WITH_CREDENTIALS: false,
+  CREDENTIALS: "include",
+  TOKEN: undefined,
+  USERNAME: undefined,
+  PASSWORD: undefined,
+  HEADERS: undefined,
+  ENCODE_PATH: undefined,
 };

--- a/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
+++ b/taxonomy-editor-frontend/src/client/core/OpenAPI.ts
@@ -22,7 +22,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     // TODO: Used to keep API_URL backward compatible with existing code, update API_URL when possible
-    BASE: API_URL.substring(0, API_URL.length - 2),
+    BASE: API_URL.substring(0, API_URL.length - 1),
     VERSION: '0.1.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',

--- a/taxonomy-editor-frontend/src/client/core/request.ts
+++ b/taxonomy-editor-frontend/src/client/core/request.ts
@@ -1,0 +1,322 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import axios from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
+import FormData from 'form-data';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+    return value !== undefined && value !== null;
+};
+
+export const isString = (value: any): value is string => {
+    return typeof value === 'string';
+};
+
+export const isStringWithValue = (value: any): value is string => {
+    return isString(value) && value !== '';
+};
+
+export const isBlob = (value: any): value is Blob => {
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
+};
+
+export const isFormData = (value: any): value is FormData => {
+    return value instanceof FormData;
+};
+
+export const isSuccess = (status: number): boolean => {
+    return status >= 200 && status < 300;
+};
+
+export const base64 = (str: string): string => {
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
+};
+
+export const getQueryString = (params: Record<string, any>): string => {
+    const qs: string[] = [];
+
+    const append = (key: string, value: any) => {
+        qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    };
+
+    const process = (key: string, value: any) => {
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(`${key}[${k}]`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
+
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
+
+    if (qs.length > 0) {
+        return `?${qs.join('&')}`;
+    }
+
+    return '';
+};
+
+const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+    const encoder = config.ENCODE_PATH || encodeURI;
+
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
+
+    const url = `${config.BASE}${path}`;
+    if (options.query) {
+        return `${url}${getQueryString(options.query)}`;
+    }
+    return url;
+};
+
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+    if (options.formData) {
+        const formData = new FormData();
+
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
+
+        Object.entries(options.formData)
+            .filter(([_, value]) => isDefined(value))
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
+
+        return formData;
+    }
+    return undefined;
+};
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
+};
+
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
+    const [token, username, password, additionalHeaders] = await Promise.all([
+        resolve(options, config.TOKEN),
+        resolve(options, config.USERNAME),
+        resolve(options, config.PASSWORD),
+        resolve(options, config.HEADERS),
+    ]);
+
+    const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
+
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+        ...formHeaders,
+    })
+    .filter(([_, value]) => isDefined(value))
+    .reduce((headers, [key, value]) => ({
+        ...headers,
+        [key]: String(value),
+    }), {} as Record<string, string>);
+
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(`${username}:${password}`);
+        headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (options.body) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
+
+    return headers;
+};
+
+export const getRequestBody = (options: ApiRequestOptions): any => {
+    if (options.body) {
+        return options.body;
+    }
+    return undefined;
+};
+
+export const sendRequest = async <T>(
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Record<string, string>,
+    onCancel: OnCancel,
+    axiosClient: AxiosInstance
+): Promise<AxiosResponse<T>> => {
+    const source = axios.CancelToken.source();
+
+    const requestConfig: AxiosRequestConfig = {
+        url,
+        headers,
+        data: body ?? formData,
+        method: options.method,
+        withCredentials: config.WITH_CREDENTIALS,
+        cancelToken: source.token,
+    };
+
+    onCancel(() => source.cancel('The user aborted a request.'));
+
+    try {
+        return await axiosClient.request(requestConfig);
+    } catch (error) {
+        const axiosError = error as AxiosError<T>;
+        if (axiosError.response) {
+            return axiosError.response;
+        }
+        throw error;
+    }
+};
+
+export const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
+    if (responseHeader) {
+        const content = response.headers[responseHeader];
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
+};
+
+export const getResponseBody = (response: AxiosResponse<any>): any => {
+    if (response.status !== 204) {
+        return response.data;
+    }
+    return undefined;
+};
+
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
+
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
+
+        throw new ApiError(options, result,
+            `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
+        );
+    }
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @param axiosClient The axios client instance to use
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options, formData);
+
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
+                const responseBody = getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
+
+                const result: ApiResult = {
+                    url,
+                    ok: isSuccess(response.status),
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
+
+                catchErrorCodes(options, result);
+
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};

--- a/taxonomy-editor-frontend/src/client/core/request.ts
+++ b/taxonomy-editor-frontend/src/client/core/request.ts
@@ -2,284 +2,313 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import axios from 'axios';
-import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
-import FormData from 'form-data';
+import axios from "axios";
+import type {
+  AxiosError,
+  AxiosRequestConfig,
+  AxiosResponse,
+  AxiosInstance,
+} from "axios";
+import FormData from "form-data";
 
-import { ApiError } from './ApiError';
-import type { ApiRequestOptions } from './ApiRequestOptions';
-import type { ApiResult } from './ApiResult';
-import { CancelablePromise } from './CancelablePromise';
-import type { OnCancel } from './CancelablePromise';
-import type { OpenAPIConfig } from './OpenAPI';
+import { ApiError } from "./ApiError";
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+import type { ApiResult } from "./ApiResult";
+import { CancelablePromise } from "./CancelablePromise";
+import type { OnCancel } from "./CancelablePromise";
+import type { OpenAPIConfig } from "./OpenAPI";
 
-export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
-    return value !== undefined && value !== null;
+export const isDefined = <T>(
+  value: T | null | undefined
+): value is Exclude<T, null | undefined> => {
+  return value !== undefined && value !== null;
 };
 
 export const isString = (value: any): value is string => {
-    return typeof value === 'string';
+  return typeof value === "string";
 };
 
 export const isStringWithValue = (value: any): value is string => {
-    return isString(value) && value !== '';
+  return isString(value) && value !== "";
 };
 
 export const isBlob = (value: any): value is Blob => {
-    return (
-        typeof value === 'object' &&
-        typeof value.type === 'string' &&
-        typeof value.stream === 'function' &&
-        typeof value.arrayBuffer === 'function' &&
-        typeof value.constructor === 'function' &&
-        typeof value.constructor.name === 'string' &&
-        /^(Blob|File)$/.test(value.constructor.name) &&
-        /^(Blob|File)$/.test(value[Symbol.toStringTag])
-    );
+  return (
+    typeof value === "object" &&
+    typeof value.type === "string" &&
+    typeof value.stream === "function" &&
+    typeof value.arrayBuffer === "function" &&
+    typeof value.constructor === "function" &&
+    typeof value.constructor.name === "string" &&
+    /^(Blob|File)$/.test(value.constructor.name) &&
+    /^(Blob|File)$/.test(value[Symbol.toStringTag])
+  );
 };
 
 export const isFormData = (value: any): value is FormData => {
-    return value instanceof FormData;
+  return value instanceof FormData;
 };
 
 export const isSuccess = (status: number): boolean => {
-    return status >= 200 && status < 300;
+  return status >= 200 && status < 300;
 };
 
 export const base64 = (str: string): string => {
-    try {
-        return btoa(str);
-    } catch (err) {
-        // @ts-ignore
-        return Buffer.from(str).toString('base64');
-    }
+  try {
+    return btoa(str);
+  } catch (err) {
+    // @ts-ignore
+    return Buffer.from(str).toString("base64");
+  }
 };
 
 export const getQueryString = (params: Record<string, any>): string => {
-    const qs: string[] = [];
+  const qs: string[] = [];
 
-    const append = (key: string, value: any) => {
-        qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
-    };
+  const append = (key: string, value: any) => {
+    qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  };
 
-    const process = (key: string, value: any) => {
-        if (isDefined(value)) {
-            if (Array.isArray(value)) {
-                value.forEach(v => {
-                    process(key, v);
-                });
-            } else if (typeof value === 'object') {
-                Object.entries(value).forEach(([k, v]) => {
-                    process(`${key}[${k}]`, v);
-                });
-            } else {
-                append(key, value);
-            }
-        }
-    };
-
-    Object.entries(params).forEach(([key, value]) => {
-        process(key, value);
-    });
-
-    if (qs.length > 0) {
-        return `?${qs.join('&')}`;
+  const process = (key: string, value: any) => {
+    if (isDefined(value)) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => {
+          process(key, v);
+        });
+      } else if (typeof value === "object") {
+        Object.entries(value).forEach(([k, v]) => {
+          process(`${key}[${k}]`, v);
+        });
+      } else {
+        append(key, value);
+      }
     }
+  };
 
-    return '';
+  Object.entries(params).forEach(([key, value]) => {
+    process(key, value);
+  });
+
+  if (qs.length > 0) {
+    return `?${qs.join("&")}`;
+  }
+
+  return "";
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-    const encoder = config.ENCODE_PATH || encodeURI;
+  const encoder = config.ENCODE_PATH || encodeURI;
 
-    const path = options.url
-        .replace('{api-version}', config.VERSION)
-        .replace(/{(.*?)}/g, (substring: string, group: string) => {
-            if (options.path?.hasOwnProperty(group)) {
-                return encoder(String(options.path[group]));
-            }
-            return substring;
-        });
+  const path = options.url
+    .replace("{api-version}", config.VERSION)
+    .replace(/{(.*?)}/g, (substring: string, group: string) => {
+      if (options.path?.hasOwnProperty(group)) {
+        return encoder(String(options.path[group]));
+      }
+      return substring;
+    });
 
-    const url = `${config.BASE}${path}`;
-    if (options.query) {
-        return `${url}${getQueryString(options.query)}`;
-    }
-    return url;
+  const url = `${config.BASE}${path}`;
+  if (options.query) {
+    return `${url}${getQueryString(options.query)}`;
+  }
+  return url;
 };
 
-export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-    if (options.formData) {
-        const formData = new FormData();
+export const getFormData = (
+  options: ApiRequestOptions
+): FormData | undefined => {
+  if (options.formData) {
+    const formData = new FormData();
 
-        const process = (key: string, value: any) => {
-            if (isString(value) || isBlob(value)) {
-                formData.append(key, value);
-            } else {
-                formData.append(key, JSON.stringify(value));
-            }
-        };
+    const process = (key: string, value: any) => {
+      if (isString(value) || isBlob(value)) {
+        formData.append(key, value);
+      } else {
+        formData.append(key, JSON.stringify(value));
+      }
+    };
 
-        Object.entries(options.formData)
-            .filter(([_, value]) => isDefined(value))
-            .forEach(([key, value]) => {
-                if (Array.isArray(value)) {
-                    value.forEach(v => process(key, v));
-                } else {
-                    process(key, value);
-                }
-            });
+    Object.entries(options.formData)
+      .filter(([_, value]) => isDefined(value))
+      .forEach(([key, value]) => {
+        if (Array.isArray(value)) {
+          value.forEach((v) => process(key, v));
+        } else {
+          process(key, value);
+        }
+      });
 
-        return formData;
-    }
-    return undefined;
+    return formData;
+  }
+  return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
-export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-    if (typeof resolver === 'function') {
-        return (resolver as Resolver<T>)(options);
-    }
-    return resolver;
+export const resolve = async <T>(
+  options: ApiRequestOptions,
+  resolver?: T | Resolver<T>
+): Promise<T | undefined> => {
+  if (typeof resolver === "function") {
+    return (resolver as Resolver<T>)(options);
+  }
+  return resolver;
 };
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
-    const [token, username, password, additionalHeaders] = await Promise.all([
-        resolve(options, config.TOKEN),
-        resolve(options, config.USERNAME),
-        resolve(options, config.PASSWORD),
-        resolve(options, config.HEADERS),
-    ]);
+export const getHeaders = async (
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  formData?: FormData
+): Promise<Record<string, string>> => {
+  const [token, username, password, additionalHeaders] = await Promise.all([
+    resolve(options, config.TOKEN),
+    resolve(options, config.USERNAME),
+    resolve(options, config.PASSWORD),
+    resolve(options, config.HEADERS),
+  ]);
 
-    const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
+  const formHeaders =
+    (typeof formData?.getHeaders === "function" && formData?.getHeaders()) ||
+    {};
 
-    const headers = Object.entries({
-        Accept: 'application/json',
-        ...additionalHeaders,
-        ...options.headers,
-        ...formHeaders,
-    })
+  const headers = Object.entries({
+    Accept: "application/json",
+    ...additionalHeaders,
+    ...options.headers,
+    ...formHeaders,
+  })
     .filter(([_, value]) => isDefined(value))
-    .reduce((headers, [key, value]) => ({
+    .reduce(
+      (headers, [key, value]) => ({
         ...headers,
         [key]: String(value),
-    }), {} as Record<string, string>);
+      }),
+      {} as Record<string, string>
+    );
 
-    if (isStringWithValue(token)) {
-        headers['Authorization'] = `Bearer ${token}`;
+  if (isStringWithValue(token)) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  if (isStringWithValue(username) && isStringWithValue(password)) {
+    const credentials = base64(`${username}:${password}`);
+    headers["Authorization"] = `Basic ${credentials}`;
+  }
+
+  if (options.body) {
+    if (options.mediaType) {
+      headers["Content-Type"] = options.mediaType;
+    } else if (isBlob(options.body)) {
+      headers["Content-Type"] = options.body.type || "application/octet-stream";
+    } else if (isString(options.body)) {
+      headers["Content-Type"] = "text/plain";
+    } else if (!isFormData(options.body)) {
+      headers["Content-Type"] = "application/json";
     }
+  }
 
-    if (isStringWithValue(username) && isStringWithValue(password)) {
-        const credentials = base64(`${username}:${password}`);
-        headers['Authorization'] = `Basic ${credentials}`;
-    }
-
-    if (options.body) {
-        if (options.mediaType) {
-            headers['Content-Type'] = options.mediaType;
-        } else if (isBlob(options.body)) {
-            headers['Content-Type'] = options.body.type || 'application/octet-stream';
-        } else if (isString(options.body)) {
-            headers['Content-Type'] = 'text/plain';
-        } else if (!isFormData(options.body)) {
-            headers['Content-Type'] = 'application/json';
-        }
-    }
-
-    return headers;
+  return headers;
 };
 
 export const getRequestBody = (options: ApiRequestOptions): any => {
-    if (options.body) {
-        return options.body;
-    }
-    return undefined;
+  if (options.body) {
+    return options.body;
+  }
+  return undefined;
 };
 
 export const sendRequest = async <T>(
-    config: OpenAPIConfig,
-    options: ApiRequestOptions,
-    url: string,
-    body: any,
-    formData: FormData | undefined,
-    headers: Record<string, string>,
-    onCancel: OnCancel,
-    axiosClient: AxiosInstance
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  url: string,
+  body: any,
+  formData: FormData | undefined,
+  headers: Record<string, string>,
+  onCancel: OnCancel,
+  axiosClient: AxiosInstance
 ): Promise<AxiosResponse<T>> => {
-    const source = axios.CancelToken.source();
+  const source = axios.CancelToken.source();
 
-    const requestConfig: AxiosRequestConfig = {
-        url,
-        headers,
-        data: body ?? formData,
-        method: options.method,
-        withCredentials: config.WITH_CREDENTIALS,
-        cancelToken: source.token,
-    };
+  const requestConfig: AxiosRequestConfig = {
+    url,
+    headers,
+    data: body ?? formData,
+    method: options.method,
+    withCredentials: config.WITH_CREDENTIALS,
+    cancelToken: source.token,
+  };
 
-    onCancel(() => source.cancel('The user aborted a request.'));
+  onCancel(() => source.cancel("The user aborted a request."));
 
-    try {
-        return await axiosClient.request(requestConfig);
-    } catch (error) {
-        const axiosError = error as AxiosError<T>;
-        if (axiosError.response) {
-            return axiosError.response;
-        }
-        throw error;
+  try {
+    return await axiosClient.request(requestConfig);
+  } catch (error) {
+    const axiosError = error as AxiosError<T>;
+    if (axiosError.response) {
+      return axiosError.response;
     }
+    throw error;
+  }
 };
 
-export const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
-    if (responseHeader) {
-        const content = response.headers[responseHeader];
-        if (isString(content)) {
-            return content;
-        }
+export const getResponseHeader = (
+  response: AxiosResponse<any>,
+  responseHeader?: string
+): string | undefined => {
+  if (responseHeader) {
+    const content = response.headers[responseHeader];
+    if (isString(content)) {
+      return content;
     }
-    return undefined;
+  }
+  return undefined;
 };
 
 export const getResponseBody = (response: AxiosResponse<any>): any => {
-    if (response.status !== 204) {
-        return response.data;
-    }
-    return undefined;
+  if (response.status !== 204) {
+    return response.data;
+  }
+  return undefined;
 };
 
-export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-    const errors: Record<number, string> = {
-        400: 'Bad Request',
-        401: 'Unauthorized',
-        403: 'Forbidden',
-        404: 'Not Found',
-        500: 'Internal Server Error',
-        502: 'Bad Gateway',
-        503: 'Service Unavailable',
-        ...options.errors,
-    }
+export const catchErrorCodes = (
+  options: ApiRequestOptions,
+  result: ApiResult
+): void => {
+  const errors: Record<number, string> = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    ...options.errors,
+  };
 
-    const error = errors[result.status];
-    if (error) {
-        throw new ApiError(options, result, error);
-    }
+  const error = errors[result.status];
+  if (error) {
+    throw new ApiError(options, result, error);
+  }
 
-    if (!result.ok) {
-        const errorStatus = result.status ?? 'unknown';
-        const errorStatusText = result.statusText ?? 'unknown';
-        const errorBody = (() => {
-            try {
-                return JSON.stringify(result.body, null, 2);
-            } catch (e) {
-                return undefined;
-            }
-        })();
+  if (!result.ok) {
+    const errorStatus = result.status ?? "unknown";
+    const errorStatusText = result.statusText ?? "unknown";
+    const errorBody = (() => {
+      try {
+        return JSON.stringify(result.body, null, 2);
+      } catch (e) {
+        return undefined;
+      }
+    })();
 
-        throw new ApiError(options, result,
-            `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
-        );
-    }
+    throw new ApiError(
+      options,
+      result,
+      `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
+    );
+  }
 };
 
 /**
@@ -290,33 +319,49 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @returns CancelablePromise<T>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            const url = getUrl(config, options);
-            const formData = getFormData(options);
-            const body = getRequestBody(options);
-            const headers = await getHeaders(config, options, formData);
+export const request = <T>(
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  axiosClient: AxiosInstance = axios
+): CancelablePromise<T> => {
+  return new CancelablePromise(async (resolve, reject, onCancel) => {
+    try {
+      const url = getUrl(config, options);
+      const formData = getFormData(options);
+      const body = getRequestBody(options);
+      const headers = await getHeaders(config, options, formData);
 
-            if (!onCancel.isCancelled) {
-                const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
-                const responseBody = getResponseBody(response);
-                const responseHeader = getResponseHeader(response, options.responseHeader);
+      if (!onCancel.isCancelled) {
+        const response = await sendRequest<T>(
+          config,
+          options,
+          url,
+          body,
+          formData,
+          headers,
+          onCancel,
+          axiosClient
+        );
+        const responseBody = getResponseBody(response);
+        const responseHeader = getResponseHeader(
+          response,
+          options.responseHeader
+        );
 
-                const result: ApiResult = {
-                    url,
-                    ok: isSuccess(response.status),
-                    status: response.status,
-                    statusText: response.statusText,
-                    body: responseHeader ?? responseBody,
-                };
+        const result: ApiResult = {
+          url,
+          ok: isSuccess(response.status),
+          status: response.status,
+          statusText: response.statusText,
+          body: responseHeader ?? responseBody,
+        };
 
-                catchErrorCodes(options, result);
+        catchErrorCodes(options, result);
 
-                resolve(result.body);
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
+        resolve(result.body);
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
 };

--- a/taxonomy-editor-frontend/src/client/index.ts
+++ b/taxonomy-editor-frontend/src/client/index.ts
@@ -8,6 +8,7 @@ export { OpenAPI } from "./core/OpenAPI";
 export type { OpenAPIConfig } from "./core/OpenAPI";
 
 export type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from "./models/Body_upload_taxonomy__taxonomy_name___branch__upload_post";
+export type { EntryNodeCreate } from "./models/EntryNodeCreate";
 export type { Footer } from "./models/Footer";
 export type { Header } from "./models/Header";
 export type { HTTPValidationError } from "./models/HTTPValidationError";

--- a/taxonomy-editor-frontend/src/client/index.ts
+++ b/taxonomy-editor-frontend/src/client/index.ts
@@ -2,17 +2,17 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export { ApiError } from './core/ApiError';
-export { CancelablePromise, CancelError } from './core/CancelablePromise';
-export { OpenAPI } from './core/OpenAPI';
-export type { OpenAPIConfig } from './core/OpenAPI';
+export { ApiError } from "./core/ApiError";
+export { CancelablePromise, CancelError } from "./core/CancelablePromise";
+export { OpenAPI } from "./core/OpenAPI";
+export type { OpenAPIConfig } from "./core/OpenAPI";
 
-export type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from './models/Body_upload_taxonomy__taxonomy_name___branch__upload_post';
-export type { Footer } from './models/Footer';
-export type { Header } from './models/Header';
-export type { HTTPValidationError } from './models/HTTPValidationError';
-export type { Project } from './models/Project';
-export { ProjectStatus } from './models/ProjectStatus';
-export type { ValidationError } from './models/ValidationError';
+export type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from "./models/Body_upload_taxonomy__taxonomy_name___branch__upload_post";
+export type { Footer } from "./models/Footer";
+export type { Header } from "./models/Header";
+export type { HTTPValidationError } from "./models/HTTPValidationError";
+export type { Project } from "./models/Project";
+export { ProjectStatus } from "./models/ProjectStatus";
+export type { ValidationError } from "./models/ValidationError";
 
-export { DefaultService } from './services/DefaultService';
+export { DefaultService } from "./services/DefaultService";

--- a/taxonomy-editor-frontend/src/client/index.ts
+++ b/taxonomy-editor-frontend/src/client/index.ts
@@ -11,6 +11,7 @@ export type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from '
 export type { Footer } from './models/Footer';
 export type { Header } from './models/Header';
 export type { HTTPValidationError } from './models/HTTPValidationError';
+export type { Project } from './models/Project';
 export { ProjectStatus } from './models/ProjectStatus';
 export type { ValidationError } from './models/ValidationError';
 

--- a/taxonomy-editor-frontend/src/client/index.ts
+++ b/taxonomy-editor-frontend/src/client/index.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from './models/Body_upload_taxonomy__taxonomy_name___branch__upload_post';
+export type { Footer } from './models/Footer';
+export type { Header } from './models/Header';
+export type { HTTPValidationError } from './models/HTTPValidationError';
+export { ProjectStatus } from './models/ProjectStatus';
+export type { ValidationError } from './models/ValidationError';
+
+export { DefaultService } from './services/DefaultService';

--- a/taxonomy-editor-frontend/src/client/models/Body_upload_taxonomy__taxonomy_name___branch__upload_post.ts
+++ b/taxonomy-editor-frontend/src/client/models/Body_upload_taxonomy__taxonomy_name___branch__upload_post.ts
@@ -3,7 +3,6 @@
 /* tslint:disable */
 /* eslint-disable */
 export type Body_upload_taxonomy__taxonomy_name___branch__upload_post = {
-    file: Blob;
-    description: string;
+  file: Blob;
+  description: string;
 };
-

--- a/taxonomy-editor-frontend/src/client/models/Body_upload_taxonomy__taxonomy_name___branch__upload_post.ts
+++ b/taxonomy-editor-frontend/src/client/models/Body_upload_taxonomy__taxonomy_name___branch__upload_post.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Body_upload_taxonomy__taxonomy_name___branch__upload_post = {
+    file: Blob;
+    description: string;
+};
+

--- a/taxonomy-editor-frontend/src/client/models/EntryNodeCreate.ts
+++ b/taxonomy-editor-frontend/src/client/models/EntryNodeCreate.ts
@@ -2,4 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type Header = {};
+export type EntryNodeCreate = {
+  name: string;
+  main_language_code: string;
+};

--- a/taxonomy-editor-frontend/src/client/models/Footer.ts
+++ b/taxonomy-editor-frontend/src/client/models/Footer.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Footer = {
+    preceding_lines: Array<any>;
+};
+

--- a/taxonomy-editor-frontend/src/client/models/Footer.ts
+++ b/taxonomy-editor-frontend/src/client/models/Footer.ts
@@ -3,6 +3,5 @@
 /* tslint:disable */
 /* eslint-disable */
 export type Footer = {
-    preceding_lines: Array<any>;
+  preceding_lines: Array<any>;
 };
-

--- a/taxonomy-editor-frontend/src/client/models/Footer.ts
+++ b/taxonomy-editor-frontend/src/client/models/Footer.ts
@@ -2,6 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type Footer = {
-  preceding_lines: Array<any>;
-};
+export type Footer = {};

--- a/taxonomy-editor-frontend/src/client/models/HTTPValidationError.ts
+++ b/taxonomy-editor-frontend/src/client/models/HTTPValidationError.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ValidationError } from './ValidationError';
+export type HTTPValidationError = {
+    detail?: Array<ValidationError>;
+};
+

--- a/taxonomy-editor-frontend/src/client/models/HTTPValidationError.ts
+++ b/taxonomy-editor-frontend/src/client/models/HTTPValidationError.ts
@@ -2,8 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ValidationError } from './ValidationError';
+import type { ValidationError } from "./ValidationError";
 export type HTTPValidationError = {
-    detail?: Array<ValidationError>;
+  detail?: Array<ValidationError>;
 };
-

--- a/taxonomy-editor-frontend/src/client/models/Header.ts
+++ b/taxonomy-editor-frontend/src/client/models/Header.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Header = {
+    preceding_lines: Array<any>;
+};
+

--- a/taxonomy-editor-frontend/src/client/models/Header.ts
+++ b/taxonomy-editor-frontend/src/client/models/Header.ts
@@ -3,6 +3,5 @@
 /* tslint:disable */
 /* eslint-disable */
 export type Header = {
-    preceding_lines: Array<any>;
+  preceding_lines: Array<any>;
 };
-

--- a/taxonomy-editor-frontend/src/client/models/Project.ts
+++ b/taxonomy-editor-frontend/src/client/models/Project.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ProjectStatus } from './ProjectStatus';
+export type Project = {
+    id: string;
+    status?: ProjectStatus;
+    taxonomy_name: string;
+    branch_name: string;
+    description: string;
+    is_from_github: boolean;
+    created_at: string;
+    github_checkout_commit_sha?: (string | null);
+    github_file_latest_sha?: (string | null);
+    github_pr_url?: (string | null);
+};
+

--- a/taxonomy-editor-frontend/src/client/models/Project.ts
+++ b/taxonomy-editor-frontend/src/client/models/Project.ts
@@ -2,17 +2,16 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ProjectStatus } from './ProjectStatus';
+import type { ProjectStatus } from "./ProjectStatus";
 export type Project = {
-    id: string;
-    status: ProjectStatus;
-    taxonomy_name: string;
-    branch_name: string;
-    description: string;
-    is_from_github: boolean;
-    created_at: string;
-    github_checkout_commit_sha?: (string | null);
-    github_file_latest_sha?: (string | null);
-    github_pr_url?: (string | null);
+  id: string;
+  status: ProjectStatus;
+  taxonomy_name: string;
+  branch_name: string;
+  description: string;
+  is_from_github: boolean;
+  created_at: string;
+  github_checkout_commit_sha?: string | null;
+  github_file_latest_sha?: string | null;
+  github_pr_url?: string | null;
 };
-

--- a/taxonomy-editor-frontend/src/client/models/Project.ts
+++ b/taxonomy-editor-frontend/src/client/models/Project.ts
@@ -5,7 +5,7 @@
 import type { ProjectStatus } from './ProjectStatus';
 export type Project = {
     id: string;
-    status?: ProjectStatus;
+    status: ProjectStatus;
     taxonomy_name: string;
     branch_name: string;
     description: string;

--- a/taxonomy-editor-frontend/src/client/models/ProjectStatus.ts
+++ b/taxonomy-editor-frontend/src/client/models/ProjectStatus.ts
@@ -3,8 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 export enum ProjectStatus {
-    OPEN = 'OPEN',
-    EXPORTED = 'EXPORTED',
-    LOADING = 'LOADING',
-    FAILED = 'FAILED',
+  OPEN = "OPEN",
+  EXPORTED = "EXPORTED",
+  LOADING = "LOADING",
+  FAILED = "FAILED",
 }

--- a/taxonomy-editor-frontend/src/client/models/ProjectStatus.ts
+++ b/taxonomy-editor-frontend/src/client/models/ProjectStatus.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export enum ProjectStatus {
+    OPEN = 'OPEN',
+    EXPORTED = 'EXPORTED',
+    LOADING = 'LOADING',
+    FAILED = 'FAILED',
+}

--- a/taxonomy-editor-frontend/src/client/models/ValidationError.ts
+++ b/taxonomy-editor-frontend/src/client/models/ValidationError.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ValidationError = {
+    loc: Array<(string | number)>;
+    msg: string;
+    type: string;
+};
+

--- a/taxonomy-editor-frontend/src/client/models/ValidationError.ts
+++ b/taxonomy-editor-frontend/src/client/models/ValidationError.ts
@@ -3,8 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type ValidationError = {
-    loc: Array<(string | number)>;
-    msg: string;
-    type: string;
+  loc: Array<string | number>;
+  msg: string;
+  type: string;
 };
-

--- a/taxonomy-editor-frontend/src/client/services/DefaultService.ts
+++ b/taxonomy-editor-frontend/src/client/services/DefaultService.ts
@@ -2,807 +2,807 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from '../models/Body_upload_taxonomy__taxonomy_name___branch__upload_post';
-import type { Footer } from '../models/Footer';
-import type { Header } from '../models/Header';
-import type { Project } from '../models/Project';
-import type { ProjectStatus } from '../models/ProjectStatus';
-import type { CancelablePromise } from '../core/CancelablePromise';
-import { OpenAPI } from '../core/OpenAPI';
-import { request as __request } from '../core/request';
+import type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from "../models/Body_upload_taxonomy__taxonomy_name___branch__upload_post";
+import type { Footer } from "../models/Footer";
+import type { Header } from "../models/Header";
+import type { Project } from "../models/Project";
+import type { ProjectStatus } from "../models/ProjectStatus";
+import type { CancelablePromise } from "../core/CancelablePromise";
+import { OpenAPI } from "../core/OpenAPI";
+import { request as __request } from "../core/request";
 export class DefaultService {
-    /**
-     * Hello
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static helloGet(): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/',
-        });
-    }
-    /**
-     * Pong
-     * Check server health
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static pongPingGet(): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/ping',
-        });
-    }
-    /**
-     * List All Projects
-     * List projects created in the Taxonomy Editor with a status filter
-     * @param status
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static listAllProjectsProjectsGet(
-        status?: (ProjectStatus | null),
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/projects',
-            query: {
-                'status': status,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Get Project Info
-     * Get information about a Taxonomy Editor project
-     * @param branch
-     * @param taxonomyName
-     * @returns Project Successful Response
-     * @throws ApiError
-     */
-    public static getProjectInfoTaxonomyNameBranchProjectGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<Project> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/project',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Set Project Status
-     * Set the status of a Taxonomy Editor project
-     * @param branch
-     * @param taxonomyName
-     * @param status
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static setProjectStatusTaxonomyNameBranchSetProjectStatusGet(
-        branch: string,
-        taxonomyName: string,
-        status?: (ProjectStatus | null),
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/set-project-status',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            query: {
-                'status': status,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find All Nodes
-     * Get all nodes within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findAllNodesTaxonomyNameBranchNodesGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/nodes',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Create Node
-     * Creating a new node in a taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static createNodeTaxonomyNameBranchNodesPost(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/nodes',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Delete Node
-     * Deleting given node from a taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static deleteNodeTaxonomyNameBranchNodesDelete(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/{taxonomy_name}/{branch}/nodes',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find All Root Nodes
-     * Get all root nodes within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findAllRootNodesTaxonomyNameBranchRootentriesGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/rootentries',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find One Entry
-     * Get entry corresponding to id within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @param entry
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findOneEntryTaxonomyNameBranchEntryEntryGet(
-        branch: string,
-        taxonomyName: string,
-        entry: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/entry/{entry}',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'entry': entry,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Edit Entry
-     * Editing an entry in a taxonomy.
-     * New key-value pairs can be added, old key-value pairs can be updated.
-     * URL will be of format '/entry/<id>'
-     * @param branch
-     * @param taxonomyName
-     * @param entry
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static editEntryTaxonomyNameBranchEntryEntryPost(
-        branch: string,
-        taxonomyName: string,
-        entry: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/entry/{entry}',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'entry': entry,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find One Entry Parents
-     * Get parents for a entry corresponding to id within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @param entry
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findOneEntryParentsTaxonomyNameBranchEntryEntryParentsGet(
-        branch: string,
-        taxonomyName: string,
-        entry: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/entry/{entry}/parents',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'entry': entry,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find One Entry Children
-     * Get children for a entry corresponding to id within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @param entry
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findOneEntryChildrenTaxonomyNameBranchEntryEntryChildrenGet(
-        branch: string,
-        taxonomyName: string,
-        entry: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/entry/{entry}/children',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'entry': entry,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Edit Entry Children
-     * Editing an entry's children in a taxonomy.
-     * New children can be added, old children can be removed.
-     * URL will be of format '/entry/<id>/children'
-     * @param branch
-     * @param taxonomyName
-     * @param entry
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static editEntryChildrenTaxonomyNameBranchEntryEntryChildrenPost(
-        branch: string,
-        taxonomyName: string,
-        entry: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/entry/{entry}/children',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'entry': entry,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find All Entries
-     * Get all entries within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findAllEntriesTaxonomyNameBranchEntryGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/entry',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find One Synonym
-     * Get synonym corresponding to id within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @param synonym
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findOneSynonymTaxonomyNameBranchSynonymSynonymGet(
-        branch: string,
-        taxonomyName: string,
-        synonym: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/synonym/{synonym}',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'synonym': synonym,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Edit Synonyms
-     * Editing a synonym in a taxonomy.
-     * New key-value pairs can be added, old key-value pairs can be updated.
-     * URL will be of format '/synonym/<id>'
-     * @param branch
-     * @param taxonomyName
-     * @param synonym
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static editSynonymsTaxonomyNameBranchSynonymSynonymPost(
-        branch: string,
-        taxonomyName: string,
-        synonym: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/synonym/{synonym}',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'synonym': synonym,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find All Synonyms
-     * Get all synonyms within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findAllSynonymsTaxonomyNameBranchSynonymGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/synonym',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find One Stopword
-     * Get stopword corresponding to id within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @param stopword
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findOneStopwordTaxonomyNameBranchStopwordStopwordGet(
-        branch: string,
-        taxonomyName: string,
-        stopword: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/stopword/{stopword}',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'stopword': stopword,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Edit Stopwords
-     * Editing a stopword in a taxonomy.
-     * New key-value pairs can be added, old key-value pairs can be updated.
-     * URL will be of format '/stopword/<id>'
-     * @param branch
-     * @param taxonomyName
-     * @param stopword
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static editStopwordsTaxonomyNameBranchStopwordStopwordPost(
-        branch: string,
-        taxonomyName: string,
-        stopword: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/stopword/{stopword}',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-                'stopword': stopword,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find All Stopwords
-     * Get all stopwords within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findAllStopwordsTaxonomyNameBranchStopwordGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/stopword',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find Header
-     * Get __header__ within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findHeaderTaxonomyNameBranchHeaderGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/header',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Edit Header
-     * Editing the __header__ in a taxonomy.
-     * @param branch
-     * @param taxonomyName
-     * @param requestBody
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static editHeaderTaxonomyNameBranchHeaderPost(
-        branch: string,
-        taxonomyName: string,
-        requestBody: Header,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/header',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find Footer
-     * Get __footer__ within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findFooterTaxonomyNameBranchFooterGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/footer',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Edit Footer
-     * Editing the __footer__ in a taxonomy.
-     * @param branch
-     * @param taxonomyName
-     * @param requestBody
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static editFooterTaxonomyNameBranchFooterPost(
-        branch: string,
-        taxonomyName: string,
-        requestBody: Footer,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/footer',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Find All Errors
-     * Get all errors within taxonomy
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static findAllErrorsTaxonomyNameBranchParsingErrorsGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/parsing_errors',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Search Node
-     * @param branch
-     * @param taxonomyName
-     * @param query
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static searchNodeTaxonomyNameBranchSearchGet(
-        branch: string,
-        taxonomyName: string,
-        query: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/search',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            query: {
-                'query': query,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Export To Text File
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static exportToTextFileTaxonomyNameBranchDownloadexportGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/downloadexport',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Export To Github
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static exportToGithubTaxonomyNameBranchGithubexportGet(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/{taxonomy_name}/{branch}/githubexport',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Import From Github
-     * Get taxonomy from Product Opener GitHub repository
-     * @param branch
-     * @param taxonomyName
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static importFromGithubTaxonomyNameBranchImportPost(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/import',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Upload Taxonomy
-     * Upload taxonomy file to be parsed
-     * @param branch
-     * @param taxonomyName
-     * @param formData
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static uploadTaxonomyTaxonomyNameBranchUploadPost(
-        branch: string,
-        taxonomyName: string,
-        formData: Body_upload_taxonomy__taxonomy_name___branch__upload_post,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/{taxonomy_name}/{branch}/upload',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            formData: formData,
-            mediaType: 'multipart/form-data',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Delete Project
-     * Delete a project
-     * @param branch
-     * @param taxonomyName
-     * @returns void
-     * @throws ApiError
-     */
-    public static deleteProjectTaxonomyNameBranchDelete(
-        branch: string,
-        taxonomyName: string,
-    ): CancelablePromise<void> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/{taxonomy_name}/{branch}',
-            path: {
-                'branch': branch,
-                'taxonomy_name': taxonomyName,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
+  /**
+   * Hello
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static helloGet(): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/",
+    });
+  }
+  /**
+   * Pong
+   * Check server health
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static pongPingGet(): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/ping",
+    });
+  }
+  /**
+   * List All Projects
+   * List projects created in the Taxonomy Editor with a status filter
+   * @param status
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static listAllProjectsProjectsGet(
+    status?: ProjectStatus | null
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/projects",
+      query: {
+        status: status,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Get Project Info
+   * Get information about a Taxonomy Editor project
+   * @param branch
+   * @param taxonomyName
+   * @returns Project Successful Response
+   * @throws ApiError
+   */
+  public static getProjectInfoTaxonomyNameBranchProjectGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<Project> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/project",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Set Project Status
+   * Set the status of a Taxonomy Editor project
+   * @param branch
+   * @param taxonomyName
+   * @param status
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static setProjectStatusTaxonomyNameBranchSetProjectStatusGet(
+    branch: string,
+    taxonomyName: string,
+    status?: ProjectStatus | null
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/set-project-status",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      query: {
+        status: status,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find All Nodes
+   * Get all nodes within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findAllNodesTaxonomyNameBranchNodesGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/nodes",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Create Node
+   * Creating a new node in a taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static createNodeTaxonomyNameBranchNodesPost(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/nodes",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Delete Node
+   * Deleting given node from a taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static deleteNodeTaxonomyNameBranchNodesDelete(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/{taxonomy_name}/{branch}/nodes",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find All Root Nodes
+   * Get all root nodes within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findAllRootNodesTaxonomyNameBranchRootentriesGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/rootentries",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find One Entry
+   * Get entry corresponding to id within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @param entry
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findOneEntryTaxonomyNameBranchEntryEntryGet(
+    branch: string,
+    taxonomyName: string,
+    entry: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/entry/{entry}",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        entry: entry,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Edit Entry
+   * Editing an entry in a taxonomy.
+   * New key-value pairs can be added, old key-value pairs can be updated.
+   * URL will be of format '/entry/<id>'
+   * @param branch
+   * @param taxonomyName
+   * @param entry
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static editEntryTaxonomyNameBranchEntryEntryPost(
+    branch: string,
+    taxonomyName: string,
+    entry: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/entry/{entry}",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        entry: entry,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find One Entry Parents
+   * Get parents for a entry corresponding to id within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @param entry
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findOneEntryParentsTaxonomyNameBranchEntryEntryParentsGet(
+    branch: string,
+    taxonomyName: string,
+    entry: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/entry/{entry}/parents",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        entry: entry,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find One Entry Children
+   * Get children for a entry corresponding to id within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @param entry
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findOneEntryChildrenTaxonomyNameBranchEntryEntryChildrenGet(
+    branch: string,
+    taxonomyName: string,
+    entry: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/entry/{entry}/children",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        entry: entry,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Edit Entry Children
+   * Editing an entry's children in a taxonomy.
+   * New children can be added, old children can be removed.
+   * URL will be of format '/entry/<id>/children'
+   * @param branch
+   * @param taxonomyName
+   * @param entry
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static editEntryChildrenTaxonomyNameBranchEntryEntryChildrenPost(
+    branch: string,
+    taxonomyName: string,
+    entry: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/entry/{entry}/children",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        entry: entry,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find All Entries
+   * Get all entries within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findAllEntriesTaxonomyNameBranchEntryGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/entry",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find One Synonym
+   * Get synonym corresponding to id within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @param synonym
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findOneSynonymTaxonomyNameBranchSynonymSynonymGet(
+    branch: string,
+    taxonomyName: string,
+    synonym: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/synonym/{synonym}",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        synonym: synonym,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Edit Synonyms
+   * Editing a synonym in a taxonomy.
+   * New key-value pairs can be added, old key-value pairs can be updated.
+   * URL will be of format '/synonym/<id>'
+   * @param branch
+   * @param taxonomyName
+   * @param synonym
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static editSynonymsTaxonomyNameBranchSynonymSynonymPost(
+    branch: string,
+    taxonomyName: string,
+    synonym: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/synonym/{synonym}",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        synonym: synonym,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find All Synonyms
+   * Get all synonyms within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findAllSynonymsTaxonomyNameBranchSynonymGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/synonym",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find One Stopword
+   * Get stopword corresponding to id within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @param stopword
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findOneStopwordTaxonomyNameBranchStopwordStopwordGet(
+    branch: string,
+    taxonomyName: string,
+    stopword: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/stopword/{stopword}",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        stopword: stopword,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Edit Stopwords
+   * Editing a stopword in a taxonomy.
+   * New key-value pairs can be added, old key-value pairs can be updated.
+   * URL will be of format '/stopword/<id>'
+   * @param branch
+   * @param taxonomyName
+   * @param stopword
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static editStopwordsTaxonomyNameBranchStopwordStopwordPost(
+    branch: string,
+    taxonomyName: string,
+    stopword: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/stopword/{stopword}",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+        stopword: stopword,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find All Stopwords
+   * Get all stopwords within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findAllStopwordsTaxonomyNameBranchStopwordGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/stopword",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find Header
+   * Get __header__ within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findHeaderTaxonomyNameBranchHeaderGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/header",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Edit Header
+   * Editing the __header__ in a taxonomy.
+   * @param branch
+   * @param taxonomyName
+   * @param requestBody
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static editHeaderTaxonomyNameBranchHeaderPost(
+    branch: string,
+    taxonomyName: string,
+    requestBody: Header
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/header",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find Footer
+   * Get __footer__ within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findFooterTaxonomyNameBranchFooterGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/footer",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Edit Footer
+   * Editing the __footer__ in a taxonomy.
+   * @param branch
+   * @param taxonomyName
+   * @param requestBody
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static editFooterTaxonomyNameBranchFooterPost(
+    branch: string,
+    taxonomyName: string,
+    requestBody: Footer
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/footer",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Find All Errors
+   * Get all errors within taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static findAllErrorsTaxonomyNameBranchParsingErrorsGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/parsing_errors",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Search Node
+   * @param branch
+   * @param taxonomyName
+   * @param query
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static searchNodeTaxonomyNameBranchSearchGet(
+    branch: string,
+    taxonomyName: string,
+    query: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/search",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      query: {
+        query: query,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Export To Text File
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static exportToTextFileTaxonomyNameBranchDownloadexportGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/downloadexport",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Export To Github
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static exportToGithubTaxonomyNameBranchGithubexportGet(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/{taxonomy_name}/{branch}/githubexport",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Import From Github
+   * Get taxonomy from Product Opener GitHub repository
+   * @param branch
+   * @param taxonomyName
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static importFromGithubTaxonomyNameBranchImportPost(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/import",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Upload Taxonomy
+   * Upload taxonomy file to be parsed
+   * @param branch
+   * @param taxonomyName
+   * @param formData
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static uploadTaxonomyTaxonomyNameBranchUploadPost(
+    branch: string,
+    taxonomyName: string,
+    formData: Body_upload_taxonomy__taxonomy_name___branch__upload_post
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/upload",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      formData: formData,
+      mediaType: "multipart/form-data",
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Delete Project
+   * Delete a project
+   * @param branch
+   * @param taxonomyName
+   * @returns void
+   * @throws ApiError
+   */
+  public static deleteProjectTaxonomyNameBranchDelete(
+    branch: string,
+    taxonomyName: string
+  ): CancelablePromise<void> {
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/{taxonomy_name}/{branch}",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
 }

--- a/taxonomy-editor-frontend/src/client/services/DefaultService.ts
+++ b/taxonomy-editor-frontend/src/client/services/DefaultService.ts
@@ -1,0 +1,783 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from '../models/Body_upload_taxonomy__taxonomy_name___branch__upload_post';
+import type { Footer } from '../models/Footer';
+import type { Header } from '../models/Header';
+import type { ProjectStatus } from '../models/ProjectStatus';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class DefaultService {
+    /**
+     * Hello
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static helloGet(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/',
+        });
+    }
+    /**
+     * Pong
+     * Check server health
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static pongPingGet(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/ping',
+        });
+    }
+    /**
+     * List All Projects
+     * List projects created in the Taxonomy Editor with a status filter
+     * @param status
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static listAllProjectsProjectsGet(
+        status?: (ProjectStatus | null),
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/projects',
+            query: {
+                'status': status,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Set Project Status
+     * Set the status of a Taxonomy Editor project
+     * @param branch
+     * @param taxonomyName
+     * @param status
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static setProjectStatusTaxonomyNameBranchSetProjectStatusGet(
+        branch: string,
+        taxonomyName: string,
+        status?: (ProjectStatus | null),
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/set-project-status',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            query: {
+                'status': status,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find All Nodes
+     * Get all nodes within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findAllNodesTaxonomyNameBranchNodesGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/nodes',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Node
+     * Creating a new node in a taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static createNodeTaxonomyNameBranchNodesPost(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/nodes',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Node
+     * Deleting given node from a taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static deleteNodeTaxonomyNameBranchNodesDelete(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/{taxonomy_name}/{branch}/nodes',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find All Root Nodes
+     * Get all root nodes within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findAllRootNodesTaxonomyNameBranchRootentriesGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/rootentries',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find One Entry
+     * Get entry corresponding to id within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @param entry
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findOneEntryTaxonomyNameBranchEntryEntryGet(
+        branch: string,
+        taxonomyName: string,
+        entry: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/entry/{entry}',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'entry': entry,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Edit Entry
+     * Editing an entry in a taxonomy.
+     * New key-value pairs can be added, old key-value pairs can be updated.
+     * URL will be of format '/entry/<id>'
+     * @param branch
+     * @param taxonomyName
+     * @param entry
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static editEntryTaxonomyNameBranchEntryEntryPost(
+        branch: string,
+        taxonomyName: string,
+        entry: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/entry/{entry}',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'entry': entry,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find One Entry Parents
+     * Get parents for a entry corresponding to id within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @param entry
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findOneEntryParentsTaxonomyNameBranchEntryEntryParentsGet(
+        branch: string,
+        taxonomyName: string,
+        entry: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/entry/{entry}/parents',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'entry': entry,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find One Entry Children
+     * Get children for a entry corresponding to id within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @param entry
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findOneEntryChildrenTaxonomyNameBranchEntryEntryChildrenGet(
+        branch: string,
+        taxonomyName: string,
+        entry: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/entry/{entry}/children',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'entry': entry,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Edit Entry Children
+     * Editing an entry's children in a taxonomy.
+     * New children can be added, old children can be removed.
+     * URL will be of format '/entry/<id>/children'
+     * @param branch
+     * @param taxonomyName
+     * @param entry
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static editEntryChildrenTaxonomyNameBranchEntryEntryChildrenPost(
+        branch: string,
+        taxonomyName: string,
+        entry: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/entry/{entry}/children',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'entry': entry,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find All Entries
+     * Get all entries within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findAllEntriesTaxonomyNameBranchEntryGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/entry',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find One Synonym
+     * Get synonym corresponding to id within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @param synonym
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findOneSynonymTaxonomyNameBranchSynonymSynonymGet(
+        branch: string,
+        taxonomyName: string,
+        synonym: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/synonym/{synonym}',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'synonym': synonym,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Edit Synonyms
+     * Editing a synonym in a taxonomy.
+     * New key-value pairs can be added, old key-value pairs can be updated.
+     * URL will be of format '/synonym/<id>'
+     * @param branch
+     * @param taxonomyName
+     * @param synonym
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static editSynonymsTaxonomyNameBranchSynonymSynonymPost(
+        branch: string,
+        taxonomyName: string,
+        synonym: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/synonym/{synonym}',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'synonym': synonym,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find All Synonyms
+     * Get all synonyms within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findAllSynonymsTaxonomyNameBranchSynonymGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/synonym',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find One Stopword
+     * Get stopword corresponding to id within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @param stopword
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findOneStopwordTaxonomyNameBranchStopwordStopwordGet(
+        branch: string,
+        taxonomyName: string,
+        stopword: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/stopword/{stopword}',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'stopword': stopword,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Edit Stopwords
+     * Editing a stopword in a taxonomy.
+     * New key-value pairs can be added, old key-value pairs can be updated.
+     * URL will be of format '/stopword/<id>'
+     * @param branch
+     * @param taxonomyName
+     * @param stopword
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static editStopwordsTaxonomyNameBranchStopwordStopwordPost(
+        branch: string,
+        taxonomyName: string,
+        stopword: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/stopword/{stopword}',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+                'stopword': stopword,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find All Stopwords
+     * Get all stopwords within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findAllStopwordsTaxonomyNameBranchStopwordGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/stopword',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find Header
+     * Get __header__ within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findHeaderTaxonomyNameBranchHeaderGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/header',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Edit Header
+     * Editing the __header__ in a taxonomy.
+     * @param branch
+     * @param taxonomyName
+     * @param requestBody
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static editHeaderTaxonomyNameBranchHeaderPost(
+        branch: string,
+        taxonomyName: string,
+        requestBody: Header,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/header',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find Footer
+     * Get __footer__ within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findFooterTaxonomyNameBranchFooterGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/footer',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Edit Footer
+     * Editing the __footer__ in a taxonomy.
+     * @param branch
+     * @param taxonomyName
+     * @param requestBody
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static editFooterTaxonomyNameBranchFooterPost(
+        branch: string,
+        taxonomyName: string,
+        requestBody: Footer,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/footer',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Find All Errors
+     * Get all errors within taxonomy
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static findAllErrorsTaxonomyNameBranchParsingErrorsGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/parsing_errors',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Search Node
+     * @param branch
+     * @param taxonomyName
+     * @param query
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static searchNodeTaxonomyNameBranchSearchGet(
+        branch: string,
+        taxonomyName: string,
+        query: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/search',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            query: {
+                'query': query,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Export To Text File
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static exportToTextFileTaxonomyNameBranchDownloadexportGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/downloadexport',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Export To Github
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static exportToGithubTaxonomyNameBranchGithubexportGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/githubexport',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Import From Github
+     * Get taxonomy from Product Opener GitHub repository
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static importFromGithubTaxonomyNameBranchImportPost(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/import',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Upload Taxonomy
+     * Upload taxonomy file to be parsed
+     * @param branch
+     * @param taxonomyName
+     * @param formData
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static uploadTaxonomyTaxonomyNameBranchUploadPost(
+        branch: string,
+        taxonomyName: string,
+        formData: Body_upload_taxonomy__taxonomy_name___branch__upload_post,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/{taxonomy_name}/{branch}/upload',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            formData: formData,
+            mediaType: 'multipart/form-data',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Project
+     * Delete a project
+     * @param branch
+     * @param taxonomyName
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static deleteProjectTaxonomyNameBranchDeleteDelete(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/{taxonomy_name}/{branch}/delete',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+}

--- a/taxonomy-editor-frontend/src/client/services/DefaultService.ts
+++ b/taxonomy-editor-frontend/src/client/services/DefaultService.ts
@@ -5,6 +5,7 @@
 import type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from '../models/Body_upload_taxonomy__taxonomy_name___branch__upload_post';
 import type { Footer } from '../models/Footer';
 import type { Header } from '../models/Header';
+import type { Project } from '../models/Project';
 import type { ProjectStatus } from '../models/ProjectStatus';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
@@ -48,6 +49,30 @@ export class DefaultService {
             url: '/projects',
             query: {
                 'status': status,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Project Info
+     * Get information about a Taxonomy Editor project
+     * @param branch
+     * @param taxonomyName
+     * @returns Project Successful Response
+     * @throws ApiError
+     */
+    public static getProjectInfoTaxonomyNameBranchProjectGet(
+        branch: string,
+        taxonomyName: string,
+    ): CancelablePromise<Project> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/{taxonomy_name}/{branch}/project',
+            path: {
+                'branch': branch,
+                'taxonomy_name': taxonomyName,
             },
             errors: {
                 422: `Validation Error`,
@@ -761,16 +786,16 @@ export class DefaultService {
      * Delete a project
      * @param branch
      * @param taxonomyName
-     * @returns any Successful Response
+     * @returns void
      * @throws ApiError
      */
-    public static deleteProjectTaxonomyNameBranchDeleteDelete(
+    public static deleteProjectTaxonomyNameBranchDelete(
         branch: string,
         taxonomyName: string,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return __request(OpenAPI, {
             method: 'DELETE',
-            url: '/{taxonomy_name}/{branch}/delete',
+            url: '/{taxonomy_name}/{branch}',
             path: {
                 'branch': branch,
                 'taxonomy_name': taxonomyName,

--- a/taxonomy-editor-frontend/src/client/services/DefaultService.ts
+++ b/taxonomy-editor-frontend/src/client/services/DefaultService.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { Body_upload_taxonomy__taxonomy_name___branch__upload_post } from "../models/Body_upload_taxonomy__taxonomy_name___branch__upload_post";
+import type { EntryNodeCreate } from "../models/EntryNodeCreate";
 import type { Footer } from "../models/Footer";
 import type { Header } from "../models/Header";
 import type { Project } from "../models/Project";
@@ -122,30 +123,6 @@ export class DefaultService {
   ): CancelablePromise<any> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/{taxonomy_name}/{branch}/nodes",
-      path: {
-        branch: branch,
-        taxonomy_name: taxonomyName,
-      },
-      errors: {
-        422: `Validation Error`,
-      },
-    });
-  }
-  /**
-   * Create Node
-   * Creating a new node in a taxonomy
-   * @param branch
-   * @param taxonomyName
-   * @returns any Successful Response
-   * @throws ApiError
-   */
-  public static createNodeTaxonomyNameBranchNodesPost(
-    branch: string,
-    taxonomyName: string
-  ): CancelablePromise<any> {
-    return __request(OpenAPI, {
-      method: "POST",
       url: "/{taxonomy_name}/{branch}/nodes",
       path: {
         branch: branch,
@@ -362,6 +339,34 @@ export class DefaultService {
         branch: branch,
         taxonomy_name: taxonomyName,
       },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Create Entry Node
+   * Creating a new entry node in a taxonomy
+   * @param branch
+   * @param taxonomyName
+   * @param requestBody
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static createEntryNodeTaxonomyNameBranchEntryPost(
+    branch: string,
+    taxonomyName: string,
+    requestBody: EntryNodeCreate
+  ): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/{taxonomy_name}/{branch}/entry",
+      path: {
+        branch: branch,
+        taxonomy_name: taxonomyName,
+      },
+      body: requestBody,
+      mediaType: "application/json",
       errors: {
         422: `Validation Error`,
       },

--- a/taxonomy-editor-frontend/src/components/useFetch.ts
+++ b/taxonomy-editor-frontend/src/components/useFetch.ts
@@ -57,6 +57,9 @@ type ReturnedType<DataType> = {
   errorMessage: string | null;
 };
 
+/**
+ * @deprecated Tanstack Query should be used for data fetching (https://tanstack.com/query/latest/docs/framework/react/overview) combined with the DefaultService methods
+ */
 const useFetch = <DataType>(url: string): ReturnedType<DataType> => {
   const [fetchInfo, dispatch] = useReducer<
     Reducer<ReducerStateType<DataType | null>, ActionsType<DataType>>

--- a/taxonomy-editor-frontend/src/constants.ts
+++ b/taxonomy-editor-frontend/src/constants.ts
@@ -13,7 +13,7 @@ const taxonomyApiUrlFromUi = (location: Location): string => {
     // this is a default for simple dev setup
     return process.env.REACT_APP_API_URL as string;
   }
-}
+};
 
 export const API_URL = taxonomyApiUrlFromUi(window.location);
 

--- a/taxonomy-editor-frontend/src/constants.ts
+++ b/taxonomy-editor-frontend/src/constants.ts
@@ -3,7 +3,7 @@
  * @param URL location
  * @returns string
  */
-function taxonomyApiUrlFromUi(location) {
+const taxonomyApiUrlFromUi = (location: Location): string => {
   const components = location.host.split(".");
   if (components[0] === "ui") {
     // we build api url by just replacing ui by api
@@ -11,7 +11,7 @@ function taxonomyApiUrlFromUi(location) {
     return location.protocol + "//" + components.join(".") + "/";
   } else {
     // this is a default for simple dev setup
-    return process.env.REACT_APP_API_URL;
+    return process.env.REACT_APP_API_URL as string;
   }
 }
 

--- a/taxonomy-editor-frontend/src/utils.ts
+++ b/taxonomy-editor-frontend/src/utils.ts
@@ -44,6 +44,7 @@ export const getNodeType = (id: string): NodeType => {
 /**
  * Creating base URL for server requests
  * @returns API_URL/taxonomyName/branchName/
+ * @deprecated the DefaultService methods should be used instead
  */
 export const createBaseURL = (taxonomyName: string, branchName: string) => {
   return `${API_URL}${taxonomyName}/${branchName}/`;

--- a/taxonomy-editor-frontend/tsconfig.json
+++ b/taxonomy-editor-frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
### What
- Add an automatic client SDK generator: it uses the fact that we are able to export an OpenAPI spec from FastAPI and that this spec is able to be parsed into a Typescript client

The goal is in the future to incrementally add `Pydantic` Models as return types to the path functions to serve as output validators and as documentation for the OpenAPI spec.
Thus, adding a new API call on the frontend should now involves:
- adding a Pydantic model to the return type of the API call
- using the client SDK to call the RPC instead of manually calling the API using `fetch` or `axios`. The API return types should also be imported from the SDK    
