### PR TITLE
fix(frontend): enable child creation even if no children in entry

### DIFF
--- a/taxonomy-editor-frontend/src/pages/editentry/ListEntryChildren.tsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListEntryChildren.tsx
@@ -103,21 +103,11 @@ const ListEntryChildren = ({ url, urlPrefix, setUpdateNodeChildren }) => {
     );
   }
 
-  if (!relations.length) {
-    return (
-      <Box>
-        <Typography sx={{ ml: 4 }} variant="h5">
-          No children
-        </Typography>
-      </Box>
-    );
-  }
-
   return (
     <Box>
       <Stack direction="row" alignItems="center">
         <Typography sx={{ ml: 4 }} variant="h5">
-          Children
+          {!relations.length ? "No children" : "Children"}
         </Typography>
         {!incomingData && (
           <Box sx={{ textAlign: "left", m: 3 }}>


### PR DESCRIPTION
### What
In an entry's page, we can add new children with the + button:
![Image](https://github.com/openfoodfacts/taxonomy-editor/assets/82757576/e849c144-b099-4e9e-b978-338428fdd0f5)

However, if there are no children currently, this button is hidden:

![Image](https://github.com/openfoodfacts/taxonomy-editor/assets/82757576/5c6109cc-a8d6-470d-8225-f427191e0cb3)

### Fixes bug(s)
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/fe4493a7-3215-4cc4-bbfd-b1699ba67fab)
The button is displayed in all cases.

### Part of 
https://github.com/openfoodfacts/taxonomy-editor/issues/395
