### PR TITLE
feat(frontend,backend): Add a owner to a project

### DIFF
--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -365,6 +365,7 @@ async def import_from_github(
     """
     incoming_data = await request.json()
     description = incoming_data["description"]
+    ownerName = incoming_data["ownerName"]
 
     taxonomy = TaxonomyGraph(branch, taxonomy_name)
 
@@ -375,7 +376,7 @@ async def import_from_github(
     if not await taxonomy.is_branch_unique(from_github=True):
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    status = await taxonomy.import_taxonomy(description, background_tasks)
+    status = await taxonomy.import_taxonomy(description, ownerName, background_tasks)
     return status
 
 

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -385,6 +385,7 @@ async def upload_taxonomy(
     branch: str,
     taxonomy_name: str,
     file: UploadFile,
+    owner_name: str,
     background_tasks: BackgroundTasks,
     description: str = Form(...),
 ):
@@ -399,7 +400,7 @@ async def upload_taxonomy(
     if not await taxonomy.is_branch_unique(from_github=False):
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    result = await taxonomy.import_taxonomy(description, background_tasks, file)
+    result = await taxonomy.import_taxonomy(description, owner_name, background_tasks, file)
 
     return result
 

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -385,7 +385,6 @@ async def upload_taxonomy(
     branch: str,
     taxonomy_name: str,
     file: UploadFile,
-    owner_name: str,
     background_tasks: BackgroundTasks,
     description: str = Form(...),
 ):
@@ -400,7 +399,7 @@ async def upload_taxonomy(
     if not await taxonomy.is_branch_unique(from_github=False):
         raise HTTPException(status_code=409, detail="branch_name: Branch name should be unique!")
 
-    result = await taxonomy.import_taxonomy(description, owner_name, background_tasks, file)
+    result = await taxonomy.import_taxonomy(description, "unknown", background_tasks, file)
 
     return result
 

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -217,10 +217,10 @@ class TaxonomyGraph:
                 raise GithubBranchExistsError() from e
 
         try:
-            new_file = await github_object.update_file(filename, file_sha)
+            new_file = await github_object.update_file(filename, file_sha, owner_name)
 
             if status != ProjectStatus.EXPORTED:
-                pull_request = await github_object.create_pr(description, owner_name)
+                pull_request = await github_object.create_pr(description)
                 pr_url = pull_request.html_url
 
             await edit_project(

--- a/backend/editor/entries.py
+++ b/backend/editor/entries.py
@@ -136,6 +136,7 @@ class TaxonomyGraph:
     async def import_taxonomy(
         self,
         description: str,
+        owner_name: str,
         background_tasks: BackgroundTasks,
         uploadfile: UploadFile | None = None,
     ):
@@ -148,6 +149,7 @@ class TaxonomyGraph:
                 taxonomy_name=self.taxonomy_name,
                 branch_name=self.branch_name,
                 description=description,
+                owner_name=owner_name,
                 is_from_github=uploadfile is None,
             )
         )
@@ -188,8 +190,9 @@ class TaxonomyGraph:
         Helper function to export a taxonomy to GitHub
         """
         project = await get_project(self.project_name)
-        is_from_github, status, description, commit_sha, file_sha, pr_url = (
+        is_from_github, owner_name, status, description, commit_sha, file_sha, pr_url = (
             project.is_from_github,
+            project.owner_name,
             project.status,
             project.description,
             project.github_checkout_commit_sha,
@@ -217,7 +220,7 @@ class TaxonomyGraph:
             new_file = await github_object.update_file(filename, file_sha)
 
             if status != ProjectStatus.EXPORTED:
-                pull_request = await github_object.create_pr(description)
+                pull_request = await github_object.create_pr(description, owner_name)
                 pr_url = pull_request.html_url
 
             await edit_project(

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -85,13 +85,14 @@ class GithubOperations:
             *self.repo_info, ref="refs/heads/" + self.branch_name, sha=commit_sha
         )
 
-    async def update_file(self, filename: str, file_sha: str) -> FileCommit:
+    async def update_file(self, filename: str, file_sha: str, author_name) -> FileCommit:
         """
         Update the taxonomy txt file edited by user using the Taxonomy Editor
         """
         # Find taxonomy text file to be updated
         github_filepath = f"taxonomies/{self.taxonomy_name}.txt"
         commit_message = f"Update {self.taxonomy_name}.txt"
+        author = {"name": author_name, "email": f"{author_name}@example.com"}
         try:
             with open(filename, "r") as f:
                 new_file_contents = f.read()
@@ -104,6 +105,7 @@ class GithubOperations:
                     content=base64.b64encode(new_file_contents.encode("utf-8")),
                     sha=file_sha,
                     branch=self.branch_name,
+                    committer=author,
                 )
             ).parsed_data
         except RequestFailed as e:
@@ -117,7 +119,7 @@ class GithubOperations:
             # Handle any other unexpected exceptions
             raise Exception(f"An error occurred: {e}") from e
 
-    async def create_pr(self, description, owner_name) -> PullRequest:
+    async def create_pr(self, description) -> PullRequest:
         """
         Create a pull request to "openfoodfacts-server" repo
         """
@@ -130,8 +132,6 @@ class GithubOperations:
         ### Description
         {description}
 
-        ### Author
-        {owner_name}
         """
         )
         return (

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -117,7 +117,7 @@ class GithubOperations:
             # Handle any other unexpected exceptions
             raise Exception(f"An error occurred: {e}") from e
 
-    async def create_pr(self, description) -> PullRequest:
+    async def create_pr(self, description, owner_name) -> PullRequest:
         """
         Create a pull request to "openfoodfacts-server" repo
         """
@@ -129,6 +129,9 @@ class GithubOperations:
 
         ### Description
         {description}
+
+        ### Author
+        {owner_name}
         """
         )
         return (

--- a/backend/editor/github_functions.py
+++ b/backend/editor/github_functions.py
@@ -92,10 +92,13 @@ class GithubOperations:
         # Find taxonomy text file to be updated
         github_filepath = f"taxonomies/{self.taxonomy_name}.txt"
         commit_message = f"Update {self.taxonomy_name}.txt"
-        author = {"name": author_name, "email": f"{author_name}@example.com"}
+        author = {"name": author_name, "email": "contact@openfoodfacts.org"}
         try:
             with open(filename, "r") as f:
                 new_file_contents = f.read()
+            # doc url below (2 lines)
+            # https://docs.github.com/en/rest/repos/contents?
+            # apiVersion=2022-11-28#create-or-update-file-contents
             # Update the file
             return (
                 await self.connection.rest.repos.async_create_or_update_file_contents(
@@ -105,7 +108,7 @@ class GithubOperations:
                     content=base64.b64encode(new_file_contents.encode("utf-8")),
                     sha=file_sha,
                     branch=self.branch_name,
-                    committer=author,
+                    author=author,
                 )
             ).parsed_data
         except RequestFailed as e:

--- a/backend/editor/models/project_models.py
+++ b/backend/editor/models/project_models.py
@@ -22,6 +22,7 @@ class ProjectCreate(BaseModel):
     taxonomy_name: str
     branch_name: str
     description: str
+    owner_name: str
     is_from_github: bool
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -38,7 +38,7 @@ def test_upload_taxonomy(client):
         response = client.post(
             "/test_taxonomy/test_branch/upload",
             files={"file": f},
-            data={"description": "test_description", "owner_name": "testName"},
+            data={"description": "test_description"},
         )
 
     assert response.status_code == 200
@@ -50,7 +50,7 @@ def test_add_taxonomy_invalid_branch_name(client):
         response = client.post(
             "/test_taxonomy/invalid-branch-name/upload",
             files={"file": f},
-            data={"description": "test_description", "owner_name": "testName"},
+            data={"description": "test_description"},
         )
 
     assert response.status_code == 422
@@ -64,7 +64,7 @@ def test_add_taxonomy_duplicate_project_name(client):
         response = client.post(
             "/test_taxonomy/test_branch/upload",
             files={"file": f},
-            data={"description": "test_description", "owner_name": "testName"},
+            data={"description": "test_description"},
         )
 
     assert response.status_code == 409

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -38,7 +38,7 @@ def test_upload_taxonomy(client):
         response = client.post(
             "/test_taxonomy/test_branch/upload",
             files={"file": f},
-            data={"description": "test_description"},
+            data={"description": "test_description", "owner_name": "testName"},
         )
 
     assert response.status_code == 200
@@ -50,7 +50,7 @@ def test_add_taxonomy_invalid_branch_name(client):
         response = client.post(
             "/test_taxonomy/invalid-branch-name/upload",
             files={"file": f},
-            data={"description": "test_description"},
+            data={"description": "test_description", "owner_name": "testName"},
         )
 
     assert response.status_code == 422
@@ -64,7 +64,7 @@ def test_add_taxonomy_duplicate_project_name(client):
         response = client.post(
             "/test_taxonomy/test_branch/upload",
             files={"file": f},
-            data={"description": "test_description"},
+            data={"description": "test_description", "owner_name": "testName"},
         )
 
     assert response.status_code == 409

--- a/taxonomy-editor-frontend/src/backend-types/types.ts
+++ b/taxonomy-editor-frontend/src/backend-types/types.ts
@@ -19,6 +19,7 @@ type ProjectType = {
   description: string;
   id: string;
   taxonomy_name: string;
+  owner_name: string;
   errors_count: number;
   status: string;
 };

--- a/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/go-to-project/index.tsx
@@ -15,6 +15,7 @@ type ProjectType = {
   id: string;
   projectName: string;
   taxonomyName: string;
+  ownerName: string;
   branchName: string;
   description: string;
   errors_count: number;
@@ -41,6 +42,7 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
           id,
           branch_name,
           taxonomy_name,
+          owner_name,
           description,
           errors_count,
           status,
@@ -49,6 +51,7 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
             id, // needed by MaterialTable as key
             projectName: id,
             taxonomyName: toTitleCase(taxonomy_name),
+            ownerName: owner_name ? owner_name : "unknown",
             branchName: branch_name,
             description: description,
             errors_count: errors_count,
@@ -106,6 +109,7 @@ const GoToProject = ({ clearNavBarLinks }: Props) => {
             { title: "Project", field: "projectName" },
             { title: "Taxonomy", field: "taxonomyName" },
             { title: "Branch", field: "branchName" },
+            { title: "owner", field: "ownerName" },
             { title: "Description", field: "description", width: "10vw" },
             {
               title: "Errors",

--- a/taxonomy-editor-frontend/src/pages/startproject/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/startproject/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
 import {
@@ -29,12 +29,12 @@ const StartProject = ({ clearNavBarLinks }) => {
   const [errorMessage, setErrorMessage] = useState("");
   const navigate = useNavigate();
 
-  const findDefaultBranchName = () => {
+  const findDefaultBranchName = useCallback(() => {
     if (taxonomyName === "" || ownerName === "") return "";
     return `${taxonomyName.toLowerCase()}_${ownerName
       .replace(" ", "")
       .toLowerCase()}_${Math.floor(Date.now() / 1000)}`;
-  };
+  }, [ownerName, taxonomyName]);
 
   const [branchName, setBranchName] = useState(findDefaultBranchName());
 
@@ -47,7 +47,7 @@ const StartProject = ({ clearNavBarLinks }) => {
 
   useEffect(() => {
     setBranchName(findDefaultBranchName());
-  }, [ownerName, taxonomyName]);
+  }, [ownerName, taxonomyName, findDefaultBranchName]);
 
   const handleSubmit = () => {
     if (!taxonomyName || !branchName || !ownerName) return;

--- a/taxonomy-editor-frontend/src/pages/startproject/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/startproject/index.tsx
@@ -22,12 +22,21 @@ import { createBaseURL, toSnakeCase } from "@/utils";
 const branchNameRegEx = /[^a-z0-9_]+/;
 
 const StartProject = ({ clearNavBarLinks }) => {
-  const [branchName, setBranchName] = useState("");
+  const [ownerName, setOwnerName] = useState("");
   const [taxonomyName, setTaxonomyName] = useState("");
   const [description, setDescription] = useState("");
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const navigate = useNavigate();
+
+  const findDefaultBranchName = () => {
+    if (taxonomyName === "" || ownerName === "") return "";
+    return `${taxonomyName.toLowerCase()}_${ownerName
+      .replace(" ", "")
+      .toLowerCase()}_${Math.floor(Date.now() / 1000)}`;
+  };
+
+  const [branchName, setBranchName] = useState(findDefaultBranchName());
 
   useEffect(
     function cleanMainNavLinks() {
@@ -36,12 +45,16 @@ const StartProject = ({ clearNavBarLinks }) => {
     [clearNavBarLinks]
   );
 
+  useEffect(() => {
+    setBranchName(findDefaultBranchName());
+  }, [ownerName, taxonomyName]);
+
   const handleSubmit = () => {
-    if (!taxonomyName || !branchName) return;
+    if (!taxonomyName || !branchName || !ownerName) return;
 
     const baseUrl = createBaseURL(toSnakeCase(taxonomyName), branchName);
     setLoading(true);
-    const dataToBeSent = { description: description };
+    const dataToBeSent = { description: description, ownerName: ownerName };
     let errorMessage = "Unable to import";
 
     fetch(`${baseUrl}import`, {
@@ -68,6 +81,15 @@ const StartProject = ({ clearNavBarLinks }) => {
   };
 
   const isInvalidBranchName = branchNameRegEx.test(branchName);
+
+  const isOwnerNameInvalid = (name: string) => {
+    if (name === "") return false;
+    const pattern = /^[a-zA-Z0-9 _]+$/;
+    if (!pattern.test(name)) {
+      return true;
+    }
+    return false;
+  };
 
   return (
     <Box>
@@ -99,37 +121,51 @@ const StartProject = ({ clearNavBarLinks }) => {
           </FormControl>
         </div>
 
-        <div>
-          <TextField
-            error={isInvalidBranchName}
-            helperText={
-              isInvalidBranchName &&
-              "Special characters, capital letters and white spaces are not allowed"
-            }
-            size="small"
-            sx={{ width: 265, mt: 2 }}
-            onChange={(event) => {
-              setBranchName(event.target.value);
-            }}
-            value={branchName}
-            variant="outlined"
-            label="Branch Name"
-          />
-        </div>
+        <TextField
+          error={isOwnerNameInvalid(ownerName)}
+          helperText={
+            isOwnerNameInvalid(ownerName) &&
+            "Special characters are not allowed"
+          }
+          size="small"
+          sx={{ width: 265, mt: 2 }}
+          onChange={(event) => {
+            setOwnerName(event.target.value);
+          }}
+          value={ownerName}
+          variant="outlined"
+          label="Your Name"
+          required={true}
+        />
 
-        <div>
-          <TextField
-            sx={{ width: 265, mt: 2 }}
-            minRows={4}
-            multiline
-            onChange={(event) => {
-              setDescription(event.target.value);
-            }}
-            value={description}
-            variant="outlined"
-            label="Description"
-          />
-        </div>
+        <TextField
+          error={isInvalidBranchName}
+          helperText={
+            isInvalidBranchName &&
+            "Special characters, capital letters and white spaces are not allowed"
+          }
+          size="small"
+          sx={{ width: 265, mt: 2 }}
+          onChange={(event) => {
+            setBranchName(event.target.value);
+          }}
+          value={branchName}
+          variant="outlined"
+          label="Branch Name"
+          required={true}
+        />
+
+        <TextField
+          sx={{ width: 265, mt: 2 }}
+          minRows={4}
+          multiline
+          onChange={(event) => {
+            setDescription(event.target.value);
+          }}
+          value={description}
+          variant="outlined"
+          label="Description"
+        />
 
         <Button
           variant="contained"

--- a/taxonomy-editor-frontend/src/pages/startproject/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/startproject/index.tsx
@@ -14,6 +14,7 @@ import {
   FormControl,
   Select,
   MenuItem,
+  FormHelperText,
 } from "@mui/material";
 
 import { TAXONOMY_NAMES } from "@/constants";
@@ -138,6 +139,13 @@ const StartProject = ({ clearNavBarLinks }) => {
           required={true}
         />
 
+        <FormHelperText
+          sx={{ width: "75%", textAlign: "center", maxWidth: "600px" }}
+        >
+          Please use your Github account username if possible, or eventually
+          your id on open food facts slack (so that we can contact you)
+        </FormHelperText>
+
         <TextField
           error={isInvalidBranchName}
           helperText={
@@ -166,6 +174,14 @@ const StartProject = ({ clearNavBarLinks }) => {
           variant="outlined"
           label="Description"
         />
+
+        <FormHelperText
+          sx={{ width: "75%", textAlign: "center", maxWidth: "600px" }}
+        >
+          Explain what is your goal with this new project, what changes are you
+          going to bring. Remember to privilege small projects (do big project
+          as a succession of small one).
+        </FormHelperText>
 
         <Button
           variant="contained"


### PR DESCRIPTION
### What
Previously, taxonomy projects lacked an explicit owner, leading to ambiguity regarding project ownership. This PR addresses this gap by introducing functionality to specify and display the owner's name for each project.

TO-DO :
- [x]  Add a text field to allow users to input their name when importing a new project
- [x]  Enhance the existing projects list to display the owner's name alongside each project
- [x]  the specified owner's name as the Author Name in project commits, enhancing traceability and accountability within the project's version control history

### Screenshot
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/83bfe027-cda0-4dd0-903d-1ad7ee64f778)
when importing a project, the user has to indicate a name.

![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/68616e94-e3d3-40ce-901b-3c34dcd4a282)
the author name is displayed in the existing projects table


### Part of 
[- issue 389](https://github.com/openfoodfacts/taxonomy-editor/issues/389)
[- issue 390](https://github.com/openfoodfacts/taxonomy-editor/issues/390)
