### PR TITLE
fix(frontend): fix children and parents overflow

### DIFF
--- a/taxonomy-editor-frontend/src/pages/editentry/ListEntryChildren.tsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListEntryChildren.tsx
@@ -123,7 +123,7 @@ const ListEntryChildren = ({ url, urlPrefix, setUpdateNodeChildren }) => {
       </Stack>
 
       {/* Renders parents or children of the node */}
-      <Stack direction="row">
+      <Stack direction="row" flexWrap="wrap">
         {relations.map((relationObject) => (
           <Stack
             key={relationObject["index"]}

--- a/taxonomy-editor-frontend/src/pages/editentry/ListEntryParents.tsx
+++ b/taxonomy-editor-frontend/src/pages/editentry/ListEntryParents.tsx
@@ -53,7 +53,7 @@ const ListEntryParents = ({ fetchUrl, linkHrefPrefix }: Props) => {
       <Typography sx={{ ml: 4, mb: 1 }} variant="h5">
         Parents
       </Typography>
-      <Stack direction="row">
+      <Stack direction="row" flexWrap="wrap">
         {relations.map((relation) => (
           <Link
             key={relation}


### PR DESCRIPTION
### What
- Adds a `flex-wrap` to make children and parents wrap on multiple lines instead of overflowing on the side of one line

### Screenshot

![Capture d’écran 2024-02-15 004022](https://github.com/openfoodfacts/taxonomy-editor/assets/82757576/2417efab-717c-4517-8d9c-e77f7ae622d8)


### Fixes bug(s)
- Fixes #407 
