### PR TITLE
fix(frontend): fix root nodes page infinite loading when project exported

### DIFF
--- a/taxonomy-editor-frontend/src/pages/root-nodes/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/root-nodes/index.tsx
@@ -95,9 +95,11 @@ const RootNodes = ({
     // fetch root nodes after receiving project status
     enabled:
       !!info &&
-      [ProjectStatus.OPEN, ProjectStatus.CLOSED].includes(
-        info.status as ProjectStatus
-      ),
+      [
+        ProjectStatus.OPEN,
+        ProjectStatus.CLOSED,
+        ProjectStatus.EXPORTED,
+      ].includes(info.status as ProjectStatus),
   });
 
   let nodeIds: string[] = [];


### PR DESCRIPTION
### What
- Fixes root nodes page infinite loading when project has status EXPORTED. Project having this status now disables the loading.

### Fixes bug(s)
- Fixes #412 