### PR TITLE
fix: update logo link to default /

### DIFF
--- a/taxonomy-editor-frontend/src/components/ResponsiveAppBar.tsx
+++ b/taxonomy-editor-frontend/src/components/ResponsiveAppBar.tsx
@@ -125,7 +125,8 @@ const ResponsiveAppBar = ({ displayedPages }: ResponsiveAppBarProps) => {
             >
               <MuiLink
                 sx={{ mr: 2, display: "flex", alignSelf: "center" }}
-                href="https://ui.taxonomy.openfoodfacts.net/"
+                component={Link}
+                to="/"
                 target="_blank"
               >
                 <img


### PR DESCRIPTION
### What

I've changed the Logo navigation to default '/' instead of `https://ui.taxonomy.openfoodfacts.net/`.
Used `Link` from `react-router-dom`

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
#419 
