### PR TITLE
feat(frontend): Reword export message

### DIFF
--- a/taxonomy-editor-frontend/src/pages/export/index.tsx
+++ b/taxonomy-editor-frontend/src/pages/export/index.tsx
@@ -88,8 +88,13 @@ const ExportTaxonomyToGithub = ({
         <DialogTitle>Your changes have been exported to GitHub!</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Thank you for contributing! A community member will review your
-            changes soon.
+            Thank you for your contribution! <br />
+            Please check your pull request (PR) to ensure everything looks good.
+            Feel free to add a quick description of your changes for better
+            context.
+            <br />
+            Additionnally, it&apos;s also important to monitor the PR to respond
+            to any comments from other contributors.
           </DialogContentText>
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
### What
Currently the contributor is not encouraged to watch the PR (s)he just exported on Github.

### Screenshot
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/1689815/58e3e598-8278-489c-b214-60ae003d0b1b)

### Fixes bug(s)
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/6443e898-b18e-4311-b67f-28c3759d013a)

### Part of 
[- issue 410](https://github.com/openfoodfacts/taxonomy-editor/issues/410#issue-2135855496)
