### PR TITLE
fix(backend): error on node creation from root nodes

### DIFF
--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -38,7 +38,7 @@ from .entries import TaxonomyGraph
 from .exceptions import GithubBranchExistsError, GithubUploadError
 
 # Data model imports
-from .models.node_models import EntryNodeCreate, ErrorNode, Footer, Header
+from .models.node_models import EntryNodeCreate, ErrorNode, Footer, Header, NodeType
 from .models.project_models import Project, ProjectEdit, ProjectStatus
 from .scheduler import scheduler_lifespan
 
@@ -421,7 +421,7 @@ async def create_entry_node(
     normalized_id = await taxonomy.create_entry_node(
         new_entry_node.name, new_entry_node.main_language_code
     )
-    await taxonomy.add_node_to_end("ENTRY", normalized_id)
+    await taxonomy.add_node_to_end(NodeType.ENTRY, normalized_id)
 
 
 @app.post("/{taxonomy_name}/{branch}/entry/{entry}")

--- a/backend/editor/api.py
+++ b/backend/editor/api.py
@@ -38,7 +38,7 @@ from .entries import TaxonomyGraph
 from .exceptions import GithubBranchExistsError, GithubUploadError
 
 # Data model imports
-from .models.node_models import EntryNodeCreate, ErrorNode, Footer, Header, NodeType
+from .models.node_models import EntryNodeCreate, ErrorNode, Footer, Header
 from .models.project_models import Project, ProjectEdit, ProjectStatus
 from .scheduler import scheduler_lifespan
 
@@ -421,7 +421,7 @@ async def create_entry_node(
     normalized_id = await taxonomy.create_entry_node(
         new_entry_node.name, new_entry_node.main_language_code
     )
-    await taxonomy.add_node_to_end(NodeType.ENTRY, normalized_id)
+    await taxonomy.add_node_to_end("ENTRY", normalized_id)
 
 
 @app.post("/{taxonomy_name}/{branch}/entry/{entry}")

--- a/backend/editor/models/node_models.py
+++ b/backend/editor/models/node_models.py
@@ -2,13 +2,13 @@
 Required pydantic models for API
 """
 
-from enum import Enum
+from enum import StrEnum
 
 from .base_models import BaseModel
 from .types.datetime import DateTime
 
 
-class NodeType(str, Enum):
+class NodeType(StrEnum):
     TEXT = "TEXT"
     SYNONYMS = "SYNONYMS"
     STOPWORDS = "STOPWORDS"


### PR DESCRIPTION
### What
- This PR fixes the bug that appears when the user tries to create a new node from the root nodes page.
- The issue was that for some reason, `NodeType.ENTRY` is not converted to its corresponding value (see error below). So I've decided for now to hard-code the "ENTRY" value, even if it's not optimal.

<img width="444" alt="image" src="https://github.com/openfoodfacts/taxonomy-editor/assets/82757576/93184f36-5261-4e2c-b5f1-3588803a877d">


### Fixes bug(s)
- Fixes #444
