### PR TITLE
fix: fix backwards compatibility for is:not:external search

### DIFF
--- a/backend/editor/models/search_models.py
+++ b/backend/editor/models/search_models.py
@@ -50,7 +50,7 @@ class IsFilterSearchTerm(AbstractFilterSearchTerm):
             case "external":
                 return CypherQuery("n.is_external = true")
             case "not:external":
-                return CypherQuery("n.is_external = false")
+                return CypherQuery("(n.is_external IS NULL OR n.is_external = false)")
             case _:
                 raise ValueError("Invalid filter value")
 

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -1212,6 +1212,11 @@
             },
             "type": "object",
             "title": "Comments"
+          },
+          "isExternal": {
+            "type": "boolean",
+            "title": "Isexternal",
+            "default": false
           }
         },
         "type": "object",
@@ -1330,7 +1335,14 @@
       "IsFilterSearchTerm": {
         "properties": {
           "filterType": { "const": "is", "title": "Filtertype" },
-          "filterValue": { "const": "root", "title": "Filtervalue" }
+          "filterValue": {
+            "anyOf": [
+              { "const": "root" },
+              { "const": "external" },
+              { "const": "not:external" }
+            ],
+            "title": "Filtervalue"
+          }
         },
         "type": "object",
         "required": ["filterType", "filterValue"],


### PR DESCRIPTION
### What

- Add backwards compatibility for is:not:external search (`is_external` is null on older projects)
