### PR TITLE
fix(frontend): Prevent users from navigating to child with unsaved changes

### DIFF
--- a/taxonomy-editor-frontend/src/pages/project/editentry/AccumulateAllComponents.tsx
+++ b/taxonomy-editor-frontend/src/pages/project/editentry/AccumulateAllComponents.tsx
@@ -181,6 +181,7 @@ const AccumulateAllComponents = ({
                 url={url + "/children"}
                 urlPrefix={urlPrefix}
                 setUpdateNodeChildren={setUpdateChildren}
+                hasChanges={hasChanges}
               />
               <ListTranslations
                 originalNodeObject={originalNodeObject}

--- a/taxonomy-editor-frontend/src/pages/project/editentry/AccumulateAllComponents.tsx
+++ b/taxonomy-editor-frontend/src/pages/project/editentry/AccumulateAllComponents.tsx
@@ -180,7 +180,10 @@ const AccumulateAllComponents = ({
               <ListEntryChildren
                 url={url + "/children"}
                 urlPrefix={urlPrefix}
+                updateChildren={updateChildren}
                 setUpdateNodeChildren={setUpdateChildren}
+                previousUpdateChildren={previousUpdateChildren}
+                setPreviousUpdateChildren={setPreviousUpdateChildren}
                 hasChanges={hasChanges}
               />
               <ListTranslations

--- a/taxonomy-editor-frontend/src/pages/project/editentry/ListEntryChildren.tsx
+++ b/taxonomy-editor-frontend/src/pages/project/editentry/ListEntryChildren.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   IconButton,
   Box,
+  Alert,
 } from "@mui/material";
 import { Link } from "react-router-dom";
 import { useEffect, useState } from "react";
@@ -26,7 +27,12 @@ interface Relations {
   child: string;
 }
 
-const ListEntryChildren = ({ url, urlPrefix, setUpdateNodeChildren }) => {
+const ListEntryChildren = ({
+  url,
+  urlPrefix,
+  setUpdateNodeChildren,
+  hasChanges,
+}) => {
   const [relations, setRelations] = useState<Relations[]>([]);
   const [newChild, setNewChild] = useState("");
   const [newLanguageCode, setNewLanguageCode] = useState("");
@@ -122,6 +128,14 @@ const ListEntryChildren = ({ url, urlPrefix, setUpdateNodeChildren }) => {
         </IconButton>
       </Stack>
 
+      {/* Renders warning message to save changes to be able to click on a child node */}
+      {hasChanges ? (
+        <Alert severity="warning" sx={{ mb: 1, width: "fit-content" }}>
+          Changes are pending and have not been saved. Please save your changes
+          before navigating to a child node.
+        </Alert>
+      ) : null}
+
       {/* Renders parents or children of the node */}
       <Stack direction="row" flexWrap="wrap">
         {relations.map((relationObject) => (
@@ -131,7 +145,11 @@ const ListEntryChildren = ({ url, urlPrefix, setUpdateNodeChildren }) => {
             alignItems="center"
           >
             <Link
-              to={`${urlPrefix}/entry/${relationObject["child"]}`}
+              to={
+                hasChanges
+                  ? "#"
+                  : `${urlPrefix}/entry/${relationObject["child"]}`
+              }
               style={{ color: "#0064c8", display: "inline-block" }}
             >
               <Typography sx={{ ml: 8 }} variant="h6">

--- a/taxonomy-editor-frontend/src/pages/project/editentry/ListEntryChildren.tsx
+++ b/taxonomy-editor-frontend/src/pages/project/editentry/ListEntryChildren.tsx
@@ -129,12 +129,12 @@ const ListEntryChildren = ({
       </Stack>
 
       {/* Renders warning message to save changes to be able to click on a child node */}
-      {hasChanges ? (
-        <Alert severity="warning" sx={{ mb: 1, width: "fit-content" }}>
+      {hasChanges && (
+        <Alert severity="warning" sx={{ mb: 1, ml: 4, width: "fit-content" }}>
           Changes are pending and have not been saved. Please save your changes
           before navigating to a child node.
         </Alert>
-      ) : null}
+      )}
 
       {/* Renders parents or children of the node */}
       <Stack direction="row" flexWrap="wrap">


### PR DESCRIPTION
### What
Currently, users can navigate to a child node while editing a parent node without saving changes, resulting in a potential 404 error if the child node is newly created. 
Additionally, clicking on a child node before saving changes can lead to the loss of unsaved modifications. 


To prevent this, I have disabled the ability to navigate to a child node if this node has been newly created without saving. 
Furthermore, I have implemented a warning message to inform users about why they cannot proceed to the child node : "You've just created a new child. To navigate to it, please ensure your changes are saved first."

There is another warning massage when whatever changes have not been saved : "Changes are pending and have not been saved. Please save your changes before navigating to any child node. If you prefer not to save your pending changes but wish to avoid losing them, you can navigate to a child node in a new window."

What can be added :
- a button which enables user to discard changes

### Screenshot
The child node has been added whithout saving :
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/5b23fbd7-324b-45e8-9fc9-6325af6033fc)

A change has not been saved :
![image](https://github.com/openfoodfacts/taxonomy-editor/assets/106757110/a834cdfb-195e-48ec-a6db-7088897cf207)

