### PR TITLE
fix: sort languages in search filters

### DIFF
--- a/taxonomy-editor-frontend/src/pages/project/editentry/ListEntryChildren.tsx
+++ b/taxonomy-editor-frontend/src/pages/project/editentry/ListEntryChildren.tsx
@@ -183,8 +183,7 @@ const ListEntryChildren = ({
         <DialogTitle>Add a child</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Enter the name of the child in the format
-            &quot;LC:child_tag_id&quot;
+            Enter the language code and the main name for the children
           </DialogContentText>
           <DialogContentText>Example - en:yogurts</DialogContentText>
           <Stack sx={{ mt: 2 }} direction="row" alignItems="center">

--- a/taxonomy-editor-frontend/src/pages/project/search/FiltersArea.tsx
+++ b/taxonomy-editor-frontend/src/pages/project/search/FiltersArea.tsx
@@ -138,7 +138,7 @@ export const FiltersArea = ({
       <MultipleSelectFilter
         label="Translated into"
         filterValue={chosenLanguagesCodes}
-        listOfChoices={ISO6391.getAllNames()}
+        listOfChoices={ISO6391.getAllNames().sort()}
         mapCodeToValue={ISO6391.getName}
         mapValueToCode={ISO6391.getCode}
         setQ={setQ}
@@ -148,7 +148,7 @@ export const FiltersArea = ({
       <MultipleSelectFilter
         label="Not translated into"
         filterValue={withoutChosenLanguagesCodes}
-        listOfChoices={ISO6391.getAllNames()}
+        listOfChoices={ISO6391.getAllNames().sort()}
         mapCodeToValue={ISO6391.getName}
         mapValueToCode={ISO6391.getCode}
         setQ={setQ}


### PR DESCRIPTION
From Alizarine: when I want to select a language in the "translated into" dropdown menu, the languages are not in the alphabetic order (see screenshot). It can be confusing but it's not a big deal.