### PR TITLE
fix: language order as we dump taxonomies

### DIFF
--- a/parser/openfoodfacts_taxonomy_parser/unparser.py
+++ b/parser/openfoodfacts_taxonomy_parser/unparser.py
@@ -46,7 +46,9 @@ class WriteTaxonomy:
         for property in node:
             if property.startswith(key):
                 lc_list.append(property.split("_", dash_before_lc)[dash_before_lc])
-        lc_list.sort()
+        # we sort, but with a priority for xx and en language codes
+        priority = {"en": 1, "xx": 0}
+        lc_list.sort(key=lambda name: (priority.get(name[:2], 100), name))
         return lc_list
 
     def get_tags_line(self, node, lc):

--- a/parser/openfoodfacts_taxonomy_parser/unparser.py
+++ b/parser/openfoodfacts_taxonomy_parser/unparser.py
@@ -56,11 +56,20 @@ class WriteTaxonomy:
         line = (", ").join(node["tags_" + lc])
         return lc + ":" + line
 
+    @staticmethod
+    def property_sort_key(property):
+        name, lang_code, *_ = property.split("_", 2)
+        # give priority to xx and en language codes
+        priority = {"en": 1, "xx": 0}
+        return (name, priority.get(lang_code, 100), lang_code)
+
     def list_property_and_lc(self, node):
         """return an ordered list of properties with their language code (lc)"""
         # there is no rule for the order of properties
         # properties will be arranged in alphabetical order
-        return sorted([property[5:] for property in node if property.startswith("prop_") and not property.endswith("_comments")])
+        values = [property[5:] for property in node if property.startswith("prop_") and not property.endswith("_comments")]
+        # note: using the fact that we are sure to find language code after the first underscore
+        return sorted(values, key=self.property_sort_key)
 
     def get_property_line(self, node, property):
         """return a string that should look like the original property line"""


### PR DESCRIPTION
Fix language order to match taxonomy linter preferred order.

Fixes: #511 