### PR TITLE
fix: avoid confusing language prefixes and property names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,12 +167,11 @@ tests: backend_tests ## Run all tests
 backend_tests: ## Run python tests
 	@echo "🍜 Running python tests"
 	${DOCKER_COMPOSE_TEST} up -d neo4j
-	${DOCKER_COMPOSE_TEST}  run --rm taxonomy_api pytest /parser /parser
+	${DOCKER_COMPOSE_TEST}  run --rm taxonomy_api pytest /parser
 	${DOCKER_COMPOSE_TEST}  run --rm taxonomy_api pytest /code/tests
 	${DOCKER_COMPOSE_TEST} stop neo4j
 
 checks: quality tests ## Run all checks (quality + tests)
-
 
 #------------#
 # production #

--- a/parser/openfoodfacts_taxonomy_parser/unparser.py
+++ b/parser/openfoodfacts_taxonomy_parser/unparser.py
@@ -146,4 +146,5 @@ if __name__ == "__main__":
 
     # Pass session variable to unparser object
     write = WriteTaxonomy(session)
+    import pdb;pdb.set_trace()
     write(filename, branch_name, taxonomy_name)

--- a/parser/openfoodfacts_taxonomy_parser/unparser.py
+++ b/parser/openfoodfacts_taxonomy_parser/unparser.py
@@ -146,5 +146,4 @@ if __name__ == "__main__":
 
     # Pass session variable to unparser object
     write = WriteTaxonomy(session)
-    import pdb;pdb.set_trace()
     write(filename, branch_name, taxonomy_name)

--- a/parser/tests/data/test_property_confused_lang.txt
+++ b/parser/tests/data/test_property_confused_lang.txt
@@ -1,0 +1,23 @@
+# test a bug found with labels taxonomy
+
+stopwords:en:ingredients, agricultural, from, with, of, by, the, verified, certified, approved, 100%, pure, guaranty, guaranteed, product guaranteed, product certified, standard, during, period, phase, label, mark, logo
+
+en:1% for the planet, 1 percent for the planet, one percent for the planet
+bg:1% за планетата
+ca:1% pel planeta
+de:1% für den Planeten
+es:1% para el planeta, uno por ciento para el planeta
+fi:1% planeetalle, prosentti planeetalle
+fr:1% pour la planète
+it:1% per il pianeta
+nl:1% voor de planeet
+pt:1% para o planeta, 1 porcento para o planeta, 1 por cento para o planeta, um por cento para o planeta, um porcento para o planeta
+description:en:Commit to donating at least 1% of annual sales to environmental organizations.
+image:en:1-for-the-planet.75x90.png
+label_categories:en: en:Environnment
+web:en:https://www.onepercentfortheplanet.org/
+
+
+en:100% natural
+bg:100% натурално
+ca:100% natural


### PR DESCRIPTION
We are confusing "web:en: https://xxx.com" with a synonyms entry…