### PR TITLE
fix: avoid altering original entries at parsing time

### DIFF
--- a/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
@@ -99,15 +99,11 @@ class TaxonomyParser:
                 # sanitizing
                 # remove any space characters at end of line
                 line = line.rstrip()
-                # replace ’ (typographique quote) to simple quote '
-                line = line.replace("’", "'")
                 # replace commas between digits and that have no space around by a lower comma character
                 # and do the same for escaped comma (preceded by a \)
                 # (to distinguish them from commas acting as tags separators)
                 line = re.sub(r"(\d),(\d)", r"\1‚\2", line)
                 line = re.sub(r"\\,", "\\‚", line)
-                # removes parenthesis for roman numeral
-                line = re.sub(r"\(([ivx]+)\)", r"\1", line, flags=re.I)
                 yield line_number, line
                 line_count += 1
             yield line_count, ""  # to end the last entry if not ended
@@ -260,7 +256,7 @@ class TaxonomyParser:
         saved_nodes = []
         index_stopwords = 0
         index_synonyms = 0
-        
+
         # Check if it is correctly written
         correctly_written = re.compile(r"\w+\Z")
         # stopwords will contain a list of stopwords with their language code as key

--- a/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
+++ b/parser/openfoodfacts_taxonomy_parser/parser/taxonomy_parser.py
@@ -128,7 +128,7 @@ class TaxonomyParser:
     def _get_lc_value(self, line: str, remove_stopwords=True) -> tuple[str, list[str]]:
         """Get the language code "lc" and a list of values and normalized values"""
         lc, line = line.split(":", 1)
-        values = [self.undo_normalize_text(words.strip()) for word in line.split(",")]
+        values = [self.undo_normalize_text(word.strip()) for word in line.split(",")]
         stopwords = self.stopwords if remove_stopwords else []
         tags = [normalize_text(word, lc, stopwords=stopwords) for word in values]
         return lc, values, tags

--- a/parser/openfoodfacts_taxonomy_parser/utils.py
+++ b/parser/openfoodfacts_taxonomy_parser/utils.py
@@ -9,6 +9,11 @@ def normalize_text(line: str, lang: str = "default", char: str = "-", stopwords:
     if stopwords is None:
         stopwords = {}
 
+    # replace ’ (typographique quote) to simple quote '
+    line = line.replace("’", "'")
+    # removes parenthesis for roman numeral
+    line = re.sub(r"\(([ivx]+)\)", r"\1", line, flags=re.I)
+
     line = unicodedata.normalize("NFC", line)
 
     # Removing accent


### PR DESCRIPTION
We were keeping "lower commas" in text when we parse taxonomies, and also alter parenthesis or commas.

It's problematic when we create the final PR because it induces unwanted changes.
